### PR TITLE
Omitted Blocks and Element from the default signature

### DIFF
--- a/src/blueprints/ember-cli/glimmer-component.ts
+++ b/src/blueprints/ember-cli/glimmer-component.ts
@@ -2,10 +2,6 @@ import Component from '@glimmer/component';
 
 interface <%= entity.classifiedName %>Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class <%= entity.classifiedName %>Component extends Component<<%= entity.classifiedName %>Signature> {}

--- a/src/blueprints/ember-cli/template-only-component.ts
+++ b/src/blueprints/ember-cli/template-only-component.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface <%= entity.classifiedName %>Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const <%= entity.classifiedName %>Component =

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -79,24 +79,24 @@ function convertArgsToSignature({
       false,
     ),
 
-    b.tsPropertySignature(
-      b.identifier('Blocks'),
-      b.tsTypeAnnotation(
-        b.tsTypeLiteral([
-          b.tsPropertySignature(
-            b.identifier('default'),
-            b.tsTypeAnnotation(b.tsTupleType([])),
-          ),
-        ]),
-      ),
-      false,
-    ),
+    // b.tsPropertySignature(
+    //   b.identifier('Blocks'),
+    //   b.tsTypeAnnotation(
+    //     b.tsTypeLiteral([
+    //       b.tsPropertySignature(
+    //         b.identifier('default'),
+    //         b.tsTypeAnnotation(b.tsTupleType([])),
+    //       ),
+    //     ]),
+    //   ),
+    //   false,
+    // ),
 
-    b.tsPropertySignature(
-      b.identifier('Element'),
-      b.tsTypeAnnotation(b.tsNullKeyword()),
-      false,
-    ),
+    // b.tsPropertySignature(
+    //   b.identifier('Element'),
+    //   b.tsTypeAnnotation(b.tsNullKeyword()),
+    //   false,
+    // ),
   ];
 }
 

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/navigation-menu.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/navigation-menu.ts
@@ -10,10 +10,6 @@ interface NavigationMenuSignature {
     menuItems: MenuItem[];
     name?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/products/product/card.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/products/product/card.ts
@@ -7,10 +7,6 @@ interface ProductsProductCardSignature {
     product: Product;
     redirectTo?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/products/product/image.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/products/product/image.ts
@@ -4,11 +4,7 @@ import config from 'docs-app/config/environment';
 interface ProductsProductImageSignature {
   Args: {
     src: string;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/tracks.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/tracks.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/list.ts
@@ -7,10 +7,6 @@ type TracksListSignature = {
     numColumns?: number;
     tracks?: Track[];
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 };
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/table.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form.ts
@@ -8,11 +8,7 @@ interface UiFormSignature {
     data?: Record<string, any>;
     instructions?: string;
     title?: string;
-  }
-  Blocks: {
-    default: [];
-  }
-  Element: null
+  };
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/checkbox.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/checkbox.ts
@@ -13,10 +13,6 @@ interface UiFormCheckboxSignature {
     label: string;
     onUpdate: ({ key, value }: { key: string; value: any }) => void;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/field.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/field.ts
@@ -6,11 +6,7 @@ interface UiFormFieldSignature {
     errorMessage?: string;
     isInline?: boolean;
     isWide?: boolean;
-  }
-  Blocks: {
-    default: [];
-  }
-  Element: null
+  };
 }
 
 export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/information.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/information.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/input.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/input.ts
@@ -14,10 +14,6 @@ interface UiFormInputSignature {
     placeholder?: string;
     type?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormInputComponent extends Component<UiFormInputSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/textarea.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/textarea.ts
@@ -13,10 +13,6 @@ interface UiFormTextareaSignature {
     onUpdate: ({ key, value }: { key: string; value: any }) => void;
     placeholder?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/page.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/page.ts
@@ -3,11 +3,7 @@ import Component from '@glimmer/component';
 interface UiPageSignature {
   Args: {
     title: string;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-1.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-1/item.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-1/item.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2.ts
@@ -10,10 +10,6 @@ import {
 
 interface WidgetsWidget2Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2/captions.ts
@@ -19,10 +19,6 @@ interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Summary[];
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2/stacked-chart.ts
@@ -5,11 +5,7 @@ import type { Data } from '../../../utils/components/widgets/widget-2';
 interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Data[];
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3.ts
@@ -6,10 +6,6 @@ import concertData from '../../data/concert';
 
 interface WidgetsWidget3Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3/tour-schedule.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -9,11 +9,7 @@ import { findBestFittingImage } from '../../../../utils/components/widgets/widge
 interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Image[];
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 type WidgetsWidget4Signature = {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 };
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4MemoSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo/actions.ts
@@ -4,11 +4,7 @@ import type { QueryResults } from 'ember-container-query';
 interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-5.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-5.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget5Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget5Component =

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-1.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-4.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-4.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-4/memo.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4MemoSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget4MemoComponent =

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-5.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-5.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget5Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget5Component = templateOnlyComponent<WidgetsWidget5Signature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/navigation-menu/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/navigation-menu/index.ts
@@ -10,10 +10,6 @@ interface NavigationMenuSignature {
     menuItems: MenuItem[];
     name?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/products/product/card/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/products/product/card/index.ts
@@ -7,10 +7,6 @@ interface ProductsProductCardSignature {
     product: Product;
     redirectTo?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/products/product/image/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/products/product/image/index.ts
@@ -4,11 +4,7 @@ import config from 'docs-app/config/environment';
 interface ProductsProductImageSignature {
   Args: {
     src: string;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.ts
@@ -7,10 +7,6 @@ type TracksListSignature = {
     numColumns?: number;
     tracks?: Track[];
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 };
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/table/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/table/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/checkbox/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/checkbox/index.ts
@@ -13,10 +13,6 @@ interface UiFormCheckboxSignature {
     label: string;
     onUpdate: ({ key, value }: { key: string; value: any }) => void;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/field/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/field/index.ts
@@ -6,11 +6,7 @@ interface UiFormFieldSignature {
     errorMessage?: string;
     isInline?: boolean;
     isWide?: boolean;
-  }
-  Blocks: {
-    default: [];
-  }
-  Element: null
+  };
 }
 
 export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/index.ts
@@ -8,11 +8,7 @@ interface UiFormSignature {
     data?: Record<string, any>;
     instructions?: string;
     title?: string;
-  }
-  Blocks: {
-    default: [];
-  }
-  Element: null
+  };
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/information/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/information/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/input/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/input/index.ts
@@ -14,10 +14,6 @@ interface UiFormInputSignature {
     placeholder?: string;
     type?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormInputComponent extends Component<UiFormInputSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/textarea/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/textarea/index.ts
@@ -13,10 +13,6 @@ interface UiFormTextareaSignature {
     onUpdate: ({ key, value }: { key: string; value: any }) => void;
     placeholder?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/page/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/page/index.ts
@@ -3,11 +3,7 @@ import Component from '@glimmer/component';
 interface UiPageSignature {
   Args: {
     title: string;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/item/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/item/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/captions/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/captions/index.ts
@@ -19,10 +19,6 @@ interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Summary[];
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/index.ts
@@ -10,10 +10,6 @@ import {
 
 interface WidgetsWidget2Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/stacked-chart/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/stacked-chart/index.ts
@@ -5,11 +5,7 @@ import type { Data } from '../../../../utils/components/widgets/widget-2';
 interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Data[];
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/index.ts
@@ -6,10 +6,6 @@ import concertData from '../../../data/concert';
 
 interface WidgetsWidget3Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/tour-schedule/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/tour-schedule/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/tour-schedule/responsive-image/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/tour-schedule/responsive-image/index.ts
@@ -9,11 +9,7 @@ import { findBestFittingImage } from '../../../../../utils/components/widgets/wi
 interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Image[];
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 type WidgetsWidget4Signature = {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 };
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/actions/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/actions/index.ts
@@ -4,11 +4,7 @@ import type { QueryResults } from 'ember-container-query';
 interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4MemoSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-5/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-5/index.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget5Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget5Component =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.ts
@@ -2,10 +2,6 @@ import Component from '@glimmer/component';
 
 interface TracksSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class TracksComponent extends Component<TracksSignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
@@ -2,10 +2,6 @@ import Component from '@glimmer/component';
 
 interface TracksListSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/table.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
@@ -5,10 +5,6 @@ import { tracked } from '@glimmer/tracking';
 
 interface UiFormSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/checkbox.ts
@@ -3,10 +3,6 @@ import Component from '@glimmer/component';
 
 interface UiFormCheckboxSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/field.ts
@@ -3,10 +3,6 @@ import Component from '@glimmer/component';
 
 interface UiFormFieldSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/information.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
@@ -3,10 +3,6 @@ import Component from '@glimmer/component';
 
 interface UiFormInputSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormInputComponent extends Component<UiFormInputSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/textarea.ts
@@ -3,10 +3,6 @@ import Component from '@glimmer/component';
 
 interface UiFormTextareaSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/page.ts
@@ -2,10 +2,6 @@ import Component from '@glimmer/component';
 
 interface UiPageSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1/item.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1/item.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2.ts
@@ -10,10 +10,6 @@ import {
 
 interface WidgetsWidget2Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/captions.ts
@@ -17,10 +17,6 @@ const colorSvg = modifier((container: Element, [color]: [string]) => {
 
 interface WidgetsWidget2CaptionsSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -2,10 +2,6 @@ import Component from '@glimmer/component';
 
 interface WidgetsWidget2StackedChartSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3.ts
@@ -6,10 +6,6 @@ import concertData from '../../data/concert';
 
 interface WidgetsWidget3Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -7,10 +7,6 @@ import { findBestFittingImage } from '../../../../utils/components/widgets/widge
 
 interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-5.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget5Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget5Component =

--- a/tests/fixtures/ember-container-query/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/navigation-menu.ts
@@ -10,10 +10,6 @@ interface NavigationMenuSignature {
     menuItems: MenuItem[];
     name?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

--- a/tests/fixtures/ember-container-query/output/app/components/products/product/card.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/products/product/card.ts
@@ -7,10 +7,6 @@ interface ProductsProductCardSignature {
     product: Product;
     redirectTo?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();

--- a/tests/fixtures/ember-container-query/output/app/components/products/product/image.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/products/product/image.ts
@@ -4,11 +4,7 @@ import config from 'docs-app/config/environment';
 interface ProductsProductImageSignature {
   Args: {
     src: string;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/tracks.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks/list.ts
@@ -7,10 +7,6 @@ type TracksListSignature = {
     numColumns?: number;
     tracks?: Track[];
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 };
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks/table.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form.ts
@@ -8,11 +8,7 @@ interface UiFormSignature {
     data?: Record<string, any>;
     instructions?: string;
     title?: string;
-  }
-  Blocks: {
-    default: [];
-  }
-  Element: null
+  };
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/checkbox.ts
@@ -13,10 +13,6 @@ interface UiFormCheckboxSignature {
     label: string;
     onUpdate: ({ key, value }: { key: string; value: any }) => void;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/field.ts
@@ -6,11 +6,7 @@ interface UiFormFieldSignature {
     errorMessage?: string;
     isInline?: boolean;
     isWide?: boolean;
-  }
-  Blocks: {
-    default: [];
-  }
-  Element: null
+  };
 }
 
 export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/information.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/input.ts
@@ -14,10 +14,6 @@ interface UiFormInputSignature {
     placeholder?: string;
     type?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormInputComponent extends Component<UiFormInputSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/textarea.ts
@@ -13,10 +13,6 @@ interface UiFormTextareaSignature {
     onUpdate: ({ key, value }: { key: string; value: any }) => void;
     placeholder?: string;
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/ui/page.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/page.ts
@@ -3,11 +3,7 @@ import Component from '@glimmer/component';
 interface UiPageSignature {
   Args: {
     title: string;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1/item.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1/item.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2.ts
@@ -10,10 +10,6 @@ import {
 
 interface WidgetsWidget2Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2/captions.ts
@@ -19,10 +19,6 @@ interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Summary[];
   };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -5,11 +5,7 @@ import type { Data } from '../../../utils/components/widgets/widget-2';
 interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Data[];
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3.ts
@@ -6,10 +6,6 @@ import concertData from '../../data/concert';
 
 interface WidgetsWidget3Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -9,11 +9,7 @@ import { findBestFittingImage } from '../../../../utils/components/widgets/widge
 interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Image[];
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 type WidgetsWidget4Signature = {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 };
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4MemoSignature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo/actions.ts
@@ -4,11 +4,7 @@ import type { QueryResults } from 'ember-container-query';
 interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-  };
-  Blocks: {
-    default: [];
-  };
-  Element: null;
+  }
 }
 
 const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-5.ts
@@ -2,10 +2,6 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget5Signature {
   Args: {};
-  Blocks: {
-    default: [];
-  };
-  Element: null;
 }
 
 const WidgetsWidget5Component =


### PR DESCRIPTION
## Background

@chriskrycho provided a suggestion on [Discord](https://discord.com/channels/480462759797063690/1121413044497555486/1121414452009513102):

>  [M]aybe have it emit the `Blocks` and `Element` as commented out instead of actively present? Since we don’t really want people writing `Element: null`, we just want them to not include it _at all_ if they aren't using `...attributes`, and similarly we don't want people writing `Blocks: { default: [] }` unless they actually have a `yield`.


## Solution

I tried to use [`AST.builders.CommentLine()`](https://github.com/benjamn/ast-types/blob/v0.16.1/src/gen/builders.ts#L2604-L2614) and [`AST.builders.CommentBlock()`](https://github.com/benjamn/ast-types/blob/v0.16.1/src/gen/builders.ts#L2592-L2602) to comment out `Blocks` and `Element`. This didn't turn out to be easy (I'm still a novice in `recast`). (I imagine, we'd need to `JSON.stringify()` the `Blocks` and `Element` code, `.split()` the lines by the newline character, then pass it to the AST builder?)

As an alternative, we thought it'd be okay to omit `Blocks` and `Element` for now, until the codemod can analyze the project to add `Blocks` and `Element` correctly.

