### PR TITLE
Checked early which files create components and can be supported

### DIFF
--- a/src/steps/analyze-project.ts
+++ b/src/steps/analyze-project.ts
@@ -1,8 +1,12 @@
 import type { Context, Options } from '../types/index.js';
-import { findComponentEntities } from './analyze-project/index.js';
+import {
+  filterComponentEntities,
+  findComponentEntities,
+} from './analyze-project/index.js';
 
 export function analyzeProject(options: Options): Context {
-  const entities = findComponentEntities(options);
+  let entities = findComponentEntities(options);
+  entities = filterComponentEntities(entities, options);
 
   return {
     entities,

--- a/src/steps/analyze-project/filter-component-entities.ts
+++ b/src/steps/analyze-project/filter-component-entities.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { Entities, Options } from '../../types/index.js';
+import { getComponentFilePath } from '../../utils/files.js';
+
+function isSupported(file: string): boolean {
+  const traverse = AST.traverse(true);
+
+  let isClassicComponent = false;
+  let isComponent = false;
+
+  traverse(file, {
+    visitImportDeclaration(path) {
+      const importPath = path.node.source.value;
+
+      switch (importPath) {
+        case '@ember/component': {
+          isClassicComponent = true;
+          isComponent = true;
+
+          break;
+        }
+
+        case '@ember/component/template-only':
+        case '@glimmer/component': {
+          isComponent = true;
+
+          break;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  return isComponent && !isClassicComponent;
+}
+
+export function filterComponentEntities(
+  entities: Entities,
+  options: Options,
+): Entities {
+  const { projectRoot } = options;
+
+  const filteredEntities: Entities = new Map();
+
+  for (const [entityName, extensions] of entities) {
+    const isJavaScript = extensions.has('.js');
+
+    if (isJavaScript) {
+      continue;
+    }
+
+    const isTypeScript = extensions.has('.ts');
+
+    if (isTypeScript) {
+      const filePath = getComponentFilePath(options)(entityName);
+      const file = readFileSync(join(projectRoot, filePath), 'utf8');
+
+      if (!isSupported(file)) {
+        continue;
+      }
+    }
+
+    filteredEntities.set(entityName, extensions);
+  }
+
+  return filteredEntities;
+}

--- a/src/steps/analyze-project/index.ts
+++ b/src/steps/analyze-project/index.ts
@@ -1,1 +1,2 @@
+export * from './filter-component-entities.js';
 export * from './find-component-entities.js';

--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -17,36 +17,12 @@ type Data = {
   };
 };
 
-function cannotCreateRegistry(file: string): boolean {
+function hasRegistry(file: string): boolean {
   const traverse = AST.traverse(true);
 
   let hasRegistry = false;
-  let isClassicComponent = false;
-  let isComponent = false;
 
   traverse(file, {
-    visitImportDeclaration(path) {
-      const importPath = path.node.source.value;
-
-      switch (importPath) {
-        case '@ember/component': {
-          isClassicComponent = true;
-          isComponent = true;
-
-          break;
-        }
-
-        case '@ember/component/template-only':
-        case '@glimmer/component': {
-          isComponent = true;
-
-          break;
-        }
-      }
-
-      return false;
-    },
-
     visitTSModuleDeclaration(path) {
       // @ts-ignore: Assume that types from external packages are correct
       const moduleName = path.node.id.value;
@@ -59,11 +35,7 @@ function cannotCreateRegistry(file: string): boolean {
     },
   });
 
-  if (!isComponent) {
-    return true;
-  }
-
-  return hasRegistry || isClassicComponent;
+  return hasRegistry;
 }
 
 function createRegistry(file: string, data: Data): string {
@@ -287,7 +259,7 @@ export function createRegistries(context: Context, options: Options): void {
     try {
       let file = readFileSync(join(projectRoot, filePath), 'utf8');
 
-      if (cannotCreateRegistry(file)) {
+      if (hasRegistry(file)) {
         continue;
       }
 

--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -3,18 +3,17 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { AST } from '@codemod-utils/ast-javascript';
-import { classify, doubleColonize } from '@codemod-utils/ember-cli-string';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
-import { getComponentFilePath } from '../utils/files.js';
+import {
+  getComponentFilePath,
+  type TransformedEntityName,
+  transformEntityName,
+} from '../utils/files.js';
 
 type Data = {
-  entity: {
-    classifiedName: string;
-    doubleColonizedName: string;
-    name: string;
-  };
+  entity: TransformedEntityName;
 };
 
 function hasRegistry(file: string): boolean {
@@ -249,11 +248,7 @@ export function createRegistries(context: Context, options: Options): void {
     const filePath = getComponentFilePath(options)(entityName);
 
     const data = {
-      entity: {
-        classifiedName: classify(entityName),
-        doubleColonizedName: doubleColonize(entityName),
-        name: entityName,
-      },
+      entity: transformEntityName(entityName),
     };
 
     try {

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -3,16 +3,17 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { AST } from '@codemod-utils/ast-javascript';
-import { classify } from '@codemod-utils/ember-cli-string';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
-import { getComponentFilePath } from '../utils/files.js';
+import {
+  getComponentFilePath,
+  type TransformedEntityName,
+  transformEntityName,
+} from '../utils/files.js';
 
 type Data = {
-  entity: {
-    classifiedName: string;
-  };
+  entity: TransformedEntityName;
 };
 
 function getKeys(nodes: unknown): Set<string> {
@@ -372,9 +373,7 @@ export function createSignatures(context: Context, options: Options): void {
     const filePath = getComponentFilePath(options)(entityName);
 
     const data = {
-      entity: {
-        classifiedName: classify(entityName),
-      },
+      entity: transformEntityName(entityName),
     };
 
     try {

--- a/src/steps/create-template-only-components.ts
+++ b/src/steps/create-template-only-components.ts
@@ -2,20 +2,13 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { processTemplate } from '@codemod-utils/blueprints';
-import { classify, doubleColonize } from '@codemod-utils/ember-cli-string';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
 import { blueprintsRoot } from '../utils/blueprints.js';
-import { getComponentFilePath } from '../utils/files.js';
+import { getComponentFilePath, transformEntityName } from '../utils/files.js';
 
 function createBackingClass(entityName: string, options: Options): void {
-  const entity = {
-    classifiedName: classify(entityName),
-    doubleColonizedName: doubleColonize(entityName),
-    name: entityName,
-  };
-
   const filePath = getComponentFilePath(options)(entityName);
 
   const blueprintFile = readFileSync(
@@ -24,7 +17,7 @@ function createBackingClass(entityName: string, options: Options): void {
   );
 
   const file = processTemplate(blueprintFile, {
-    entity,
+    entity: transformEntityName(entityName),
     options,
   });
 

--- a/src/steps/create-template-only-components.ts
+++ b/src/steps/create-template-only-components.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 import { processTemplate } from '@codemod-utils/blueprints';
 import { classify, doubleColonize } from '@codemod-utils/ember-cli-string';
-import { createFiles, parseFilePath } from '@codemod-utils/files';
+import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
 import { blueprintsRoot } from '../utils/blueprints.js';
@@ -13,7 +13,6 @@ function createBackingClass(entityName: string, options: Options): void {
   const entity = {
     classifiedName: classify(entityName),
     doubleColonizedName: doubleColonize(entityName),
-    fileName: parseFilePath(entityName).name,
     name: entityName,
   };
 
@@ -37,7 +36,7 @@ export function createTemplateOnlyComponents(
   options: Options,
 ): void {
   for (const [entityName, extensions] of context.entities) {
-    const hasBackingClass = extensions.has('.js') || extensions.has('.ts');
+    const hasBackingClass = extensions.has('.ts');
 
     if (hasBackingClass) {
       continue;

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,1 +1,2 @@
 export * from './files/get-component-file-path.js';
+export * from './files/transform-entity-name.js';

--- a/src/utils/files/transform-entity-name.ts
+++ b/src/utils/files/transform-entity-name.ts
@@ -1,0 +1,15 @@
+import { classify, doubleColonize } from '@codemod-utils/ember-cli-string';
+
+export type TransformedEntityName = {
+  classifiedName: string;
+  doubleColonizedName: string;
+  name: string;
+};
+
+export function transformEntityName(entityName: string): TransformedEntityName {
+  return {
+    classifiedName: classify(entityName),
+    doubleColonizedName: doubleColonize(entityName),
+    name: entityName,
+  };
+}

--- a/tests/helpers/shared-test-setups/classic-components.ts
+++ b/tests/helpers/shared-test-setups/classic-components.ts
@@ -11,12 +11,7 @@ const codemodOptions: CodemodOptions = {
 };
 
 const context: Context = {
-  entities: new Map([
-    ['navigation-menu', new Set(['.hbs', '.ts'])],
-    ['products/product/card', new Set(['.hbs', '.js'])],
-    ['products/product/image', new Set(['.hbs', '.ts'])],
-    ['tracks', new Set(['.hbs', '.js'])],
-  ]),
+  entities: new Map(),
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -18,7 +18,6 @@ const context: Context = {
     ['tracks', new Set(['.d.ts', '.hbs'])],
     ['tracks/list', new Set(['.hbs', '.ts'])],
     ['tracks/table', new Set(['.d.ts', '.hbs'])],
-    ['types', new Set(['.ts'])],
     ['ui/form', new Set(['.hbs', '.ts'])],
     ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
     ['ui/form/field', new Set(['.hbs', '.ts'])],

--- a/tests/utils/files/transform-entity-name/base-case.test.ts
+++ b/tests/utils/files/transform-entity-name/base-case.test.ts
@@ -1,0 +1,17 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { transformEntityName } from '../../../../src/utils/files.js';
+
+test('utils | files | transform-entity-name > base case', function () {
+  assert.deepStrictEqual(transformEntityName('navigation-menu'), {
+    classifiedName: 'NavigationMenu',
+    doubleColonizedName: 'NavigationMenu',
+    name: 'navigation-menu',
+  });
+
+  assert.deepStrictEqual(transformEntityName('widgets/widget-3'), {
+    classifiedName: 'WidgetsWidget3',
+    doubleColonizedName: 'Widgets::Widget3',
+    name: 'widgets/widget-3',
+  });
+});


### PR DESCRIPTION
## Description

I checked early which files in `components` are legitimately components and can be supported (i.e. not classic components). By making an early exit like this, we can simplify the steps that follow after `analyze-project`.
