### PR TITLE
Refactored createSignatures

### DIFF
--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -239,9 +239,9 @@ export function createRegistries(context: Context, options: Options): void {
   const fileMap = new Map<string, string>();
 
   for (const [entityName, extensions] of context.entities) {
-    const isTypeScript = extensions.has('.ts');
+    const hasBackingClass = extensions.has('.ts');
 
-    if (!isTypeScript) {
+    if (!hasBackingClass) {
       continue;
     }
 

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -11,6 +11,7 @@ import {
   type TransformedEntityName,
   transformEntityName,
 } from '../utils/files.js';
+import { convertArgsToSignature } from './create-signatures/index.js';
 
 type Data = {
   entity: TransformedEntityName;
@@ -24,42 +25,6 @@ function getKeys(nodes: unknown): Set<string> {
 
 function isSignature(keys: Set<string>): boolean {
   return keys.has('Args') || keys.has('Blocks') || keys.has('Element');
-}
-
-function convertArgsToSignature({
-  b,
-  nodes,
-}: {
-  b: (typeof AST)['builders'];
-  nodes: unknown;
-}) {
-  return [
-    b.tsPropertySignature(
-      b.identifier('Args'),
-      // @ts-ignore: Assume that types from external packages are correct
-      b.tsTypeAnnotation(b.tsTypeLiteral(nodes)),
-      false,
-    ),
-
-    // b.tsPropertySignature(
-    //   b.identifier('Blocks'),
-    //   b.tsTypeAnnotation(
-    //     b.tsTypeLiteral([
-    //       b.tsPropertySignature(
-    //         b.identifier('default'),
-    //         b.tsTypeAnnotation(b.tsTupleType([])),
-    //       ),
-    //     ]),
-    //   ),
-    //   false,
-    // ),
-
-    // b.tsPropertySignature(
-    //   b.identifier('Element'),
-    //   b.tsTypeAnnotation(b.tsNullKeyword()),
-    //   false,
-    // ),
-  ];
 }
 
 function createSignature(file: string, data: Data): string {

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -364,9 +364,9 @@ export function createSignatures(context: Context, options: Options): void {
   const fileMap = new Map<string, string>();
 
   for (const [entityName, extensions] of context.entities) {
-    const isTypeScript = extensions.has('.ts');
+    const hasBackingClass = extensions.has('.ts');
 
-    if (!isTypeScript) {
+    if (!hasBackingClass) {
       continue;
     }
 

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -11,21 +11,14 @@ import {
   type TransformedEntityName,
   transformEntityName,
 } from '../utils/files.js';
-import { convertArgsToSignature } from './create-signatures/index.js';
+import {
+  convertArgsToSignature,
+  isSignature,
+} from './create-signatures/index.js';
 
 type Data = {
   entity: TransformedEntityName;
 };
-
-function getKeys(nodes: unknown): Set<string> {
-  type Node = { key: { name: string } };
-
-  return new Set((nodes as Node[]).map(({ key }) => key.name));
-}
-
-function isSignature(keys: Set<string>): boolean {
-  return keys.has('Args') || keys.has('Blocks') || keys.has('Element');
-}
 
 function createSignature(file: string, data: Data): string {
   const traverse = AST.traverse(true);
@@ -107,9 +100,7 @@ function createSignature(file: string, data: Data): string {
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
-          const keys = getKeys(typeParameter.members);
-
-          if (isSignature(keys)) {
+          if (isSignature(typeParameter.members)) {
             break;
           }
 
@@ -196,9 +187,7 @@ function createSignature(file: string, data: Data): string {
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
-          const keys = getKeys(typeParameter.members);
-
-          if (isSignature(keys)) {
+          if (isSignature(typeParameter.members)) {
             break;
           }
 
@@ -260,9 +249,7 @@ function createSignature(file: string, data: Data): string {
       path.node.id.name = `${data.entity.classifiedName}Signature`;
 
       const typeParameter = path.node.body;
-      const keys = getKeys(typeParameter.body);
-
-      if (isSignature(keys)) {
+      if (isSignature(typeParameter.body)) {
         return false;
       }
 
@@ -284,10 +271,9 @@ function createSignature(file: string, data: Data): string {
       path.node.id.name = `${data.entity.classifiedName}Signature`;
 
       const typeParameter = path.node.typeAnnotation;
-      // @ts-ignore: Assume that types from external packages are correct
-      const keys = getKeys(typeParameter.members);
 
-      if (isSignature(keys)) {
+      // @ts-ignore: Assume that types from external packages are correct
+      if (isSignature(typeParameter.members)) {
         return false;
       }
 

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { AST } from '@codemod-utils/ast-javascript';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
@@ -12,10 +10,9 @@ import {
   transformEntityName,
 } from '../utils/files.js';
 import {
-  convertArgsToSignature,
   getBaseComponentName,
-  isSignature,
   passSignatureToBaseComponent,
+  updateReferences,
 } from './create-signatures/index.js';
 
 type Data = {
@@ -29,7 +26,8 @@ function createSignature(file: string, data: Data): string {
     return file;
   }
 
-  const { interfaceName, newFile } = passSignatureToBaseComponent(file, {
+  // eslint-disable-next-line prefer-const
+  let { interfaceName, newFile } = passSignatureToBaseComponent(file, {
     baseComponentName,
     data,
   });
@@ -38,77 +36,12 @@ function createSignature(file: string, data: Data): string {
     return newFile;
   }
 
-  const traverse = AST.traverse(true);
+  ({ newFile } = updateReferences(newFile, {
+    data,
+    interfaceName,
+  }));
 
-  const ast = traverse(newFile, {
-    visitTSInterfaceDeclaration(path) {
-      // @ts-ignore: Assume that types from external packages are correct
-      if (path.node.id.name !== interfaceName) {
-        return false;
-      }
-
-      // @ts-ignore: Assume that types from external packages are correct
-      path.node.id.name = `${data.entity.classifiedName}Signature`;
-
-      const typeParameter = path.node.body;
-      if (isSignature(typeParameter.body)) {
-        return false;
-      }
-
-      typeParameter.body = convertArgsToSignature({
-        b: AST.builders,
-        nodes: typeParameter.body,
-      });
-
-      return false;
-    },
-
-    visitTSTypeAliasDeclaration(path) {
-      // @ts-ignore: Assume that types from external packages are correct
-      if (path.node.id.name !== interfaceName) {
-        return false;
-      }
-
-      // @ts-ignore: Assume that types from external packages are correct
-      path.node.id.name = `${data.entity.classifiedName}Signature`;
-
-      const typeParameter = path.node.typeAnnotation;
-
-      // @ts-ignore: Assume that types from external packages are correct
-      if (isSignature(typeParameter.members)) {
-        return false;
-      }
-
-      // @ts-ignore: Assume that types from external packages are correct
-      typeParameter.members = convertArgsToSignature({
-        b: AST.builders,
-        // @ts-ignore: Assume that types from external packages are correct
-        nodes: typeParameter.members,
-      });
-
-      return false;
-    },
-
-    visitTSTypeReference(path) {
-      if (path.node.typeName.type !== 'Identifier') {
-        return false;
-      }
-
-      if (path.node.typeName.name !== interfaceName) {
-        return false;
-      }
-
-      if (path.node.typeName.name.endsWith('Signature')) {
-        return false;
-      }
-
-      path.node.typeName.name = `${data.entity.classifiedName}Signature['Args']`;
-
-      return false;
-    },
-  });
-
-  return AST.print(ast);
+  return newFile;
 }
 
 export function createSignatures(context: Context, options: Options): void {

--- a/src/steps/create-signatures/convert-args-to-signature.ts
+++ b/src/steps/create-signatures/convert-args-to-signature.ts
@@ -1,38 +1,31 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { AST } from '@codemod-utils/ast-javascript';
 
-type Options = {
-  b: (typeof AST)['builders'];
-  nodes: unknown[];
-};
-
-export function convertArgsToSignature(options: Options) {
-  const { b, nodes } = options;
-
+export function convertArgsToSignature(nodes: unknown[]) {
   return [
-    b.tsPropertySignature(
-      b.identifier('Args'),
+    AST.builders.tsPropertySignature(
+      AST.builders.identifier('Args'),
       // @ts-ignore: Assume that types from external packages are correct
-      b.tsTypeAnnotation(b.tsTypeLiteral(nodes)),
+      AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(nodes)),
       false,
     ),
 
-    // b.tsPropertySignature(
-    //   b.identifier('Blocks'),
-    //   b.tsTypeAnnotation(
-    //     b.tsTypeLiteral([
-    //       b.tsPropertySignature(
-    //         b.identifier('default'),
-    //         b.tsTypeAnnotation(b.tsTupleType([])),
+    // AST.builders.tsPropertySignature(
+    //   AST.builders.identifier('Blocks'),
+    //   AST.builders.tsTypeAnnotation(
+    //     AST.builders.tsTypeLiteral([
+    //       AST.builders.tsPropertySignature(
+    //         AST.builders.identifier('default'),
+    //         AST.builders.tsTypeAnnotation(AST.builders.tsTupleType([])),
     //       ),
     //     ]),
     //   ),
     //   false,
     // ),
 
-    // b.tsPropertySignature(
-    //   b.identifier('Element'),
-    //   b.tsTypeAnnotation(b.tsNullKeyword()),
+    // AST.builders.tsPropertySignature(
+    //   AST.builders.identifier('Element'),
+    //   AST.builders.tsTypeAnnotation(AST.builders.tsNullKeyword()),
     //   false,
     // ),
   ];

--- a/src/steps/create-signatures/convert-args-to-signature.ts
+++ b/src/steps/create-signatures/convert-args-to-signature.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+type Options = {
+  b: (typeof AST)['builders'];
+  nodes: unknown[];
+};
+
+export function convertArgsToSignature(options: Options) {
+  const { b, nodes } = options;
+
+  return [
+    b.tsPropertySignature(
+      b.identifier('Args'),
+      // @ts-ignore: Assume that types from external packages are correct
+      b.tsTypeAnnotation(b.tsTypeLiteral(nodes)),
+      false,
+    ),
+
+    // b.tsPropertySignature(
+    //   b.identifier('Blocks'),
+    //   b.tsTypeAnnotation(
+    //     b.tsTypeLiteral([
+    //       b.tsPropertySignature(
+    //         b.identifier('default'),
+    //         b.tsTypeAnnotation(b.tsTupleType([])),
+    //       ),
+    //     ]),
+    //   ),
+    //   false,
+    // ),
+
+    // b.tsPropertySignature(
+    //   b.identifier('Element'),
+    //   b.tsTypeAnnotation(b.tsNullKeyword()),
+    //   false,
+    // ),
+  ];
+}

--- a/src/steps/create-signatures/get-base-component-name.ts
+++ b/src/steps/create-signatures/get-base-component-name.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+export function getBaseComponentName(file: string): string | undefined {
+  const traverse = AST.traverse(true);
+
+  let baseComponentName: string | undefined;
+
+  traverse(file, {
+    visitImportDeclaration(path) {
+      const importPath = path.node.source.value;
+
+      switch (importPath) {
+        case '@ember/component/template-only':
+        case '@glimmer/component': {
+          // @ts-ignore: Assume that types from external packages are correct
+          baseComponentName = path.node.specifiers[0]!.local.name;
+
+          return false;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  return baseComponentName;
+}

--- a/src/steps/create-signatures/index.ts
+++ b/src/steps/create-signatures/index.ts
@@ -1,4 +1,3 @@
-export * from './convert-args-to-signature.js';
 export * from './get-base-component-name.js';
-export * from './is-signature.js';
 export * from './pass-signature-to-base-component.js';
+export * from './update-references.js';

--- a/src/steps/create-signatures/index.ts
+++ b/src/steps/create-signatures/index.ts
@@ -1,1 +1,2 @@
 export * from './convert-args-to-signature.js';
+export * from './is-signature.js';

--- a/src/steps/create-signatures/index.ts
+++ b/src/steps/create-signatures/index.ts
@@ -1,0 +1,1 @@
+export * from './convert-args-to-signature.js';

--- a/src/steps/create-signatures/index.ts
+++ b/src/steps/create-signatures/index.ts
@@ -1,2 +1,3 @@
 export * from './convert-args-to-signature.js';
+export * from './get-base-component-name.js';
 export * from './is-signature.js';

--- a/src/steps/create-signatures/index.ts
+++ b/src/steps/create-signatures/index.ts
@@ -1,3 +1,4 @@
 export * from './convert-args-to-signature.js';
 export * from './get-base-component-name.js';
 export * from './is-signature.js';
+export * from './pass-signature-to-base-component.js';

--- a/src/steps/create-signatures/is-signature.ts
+++ b/src/steps/create-signatures/is-signature.ts
@@ -1,0 +1,11 @@
+function getKeys(nodes: unknown[]): Set<string> {
+  type Node = { key: { name: string } };
+
+  return new Set((nodes as Node[]).map(({ key }) => key.name));
+}
+
+export function isSignature(nodes: unknown[]): boolean {
+  const keys = getKeys(nodes);
+
+  return keys.has('Args') || keys.has('Blocks') || keys.has('Element');
+}

--- a/src/steps/create-signatures/pass-signature-to-base-component.ts
+++ b/src/steps/create-signatures/pass-signature-to-base-component.ts
@@ -49,12 +49,7 @@ export function passSignatureToBaseComponent(
           0,
           AST.builders.tsInterfaceDeclaration(
             AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            AST.builders.tsInterfaceBody(
-              convertArgsToSignature({
-                b: AST.builders,
-                nodes: [],
-              }),
-            ),
+            AST.builders.tsInterfaceBody(convertArgsToSignature([])),
           ),
         );
 
@@ -85,10 +80,7 @@ export function passSignatureToBaseComponent(
             AST.builders.tsInterfaceDeclaration(
               AST.builders.identifier(`${data.entity.classifiedName}Signature`),
               AST.builders.tsInterfaceBody(
-                convertArgsToSignature({
-                  b: AST.builders,
-                  nodes: typeParameter.members,
-                }),
+                convertArgsToSignature(typeParameter.members),
               ),
             ),
           );
@@ -136,12 +128,7 @@ export function passSignatureToBaseComponent(
           0,
           AST.builders.tsInterfaceDeclaration(
             AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            AST.builders.tsInterfaceBody(
-              convertArgsToSignature({
-                b: AST.builders,
-                nodes: [],
-              }),
-            ),
+            AST.builders.tsInterfaceBody(convertArgsToSignature([])),
           ),
         );
 
@@ -172,10 +159,7 @@ export function passSignatureToBaseComponent(
             AST.builders.tsInterfaceDeclaration(
               AST.builders.identifier(`${data.entity.classifiedName}Signature`),
               AST.builders.tsInterfaceBody(
-                convertArgsToSignature({
-                  b: AST.builders,
-                  nodes: typeParameter.members,
-                }),
+                convertArgsToSignature(typeParameter.members),
               ),
             ),
           );

--- a/src/steps/create-signatures/pass-signature-to-base-component.ts
+++ b/src/steps/create-signatures/pass-signature-to-base-component.ts
@@ -1,0 +1,212 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { TransformedEntityName } from '../../utils/files.js';
+import { convertArgsToSignature } from './convert-args-to-signature.js';
+import { isSignature } from './is-signature.js';
+
+type Options = {
+  baseComponentName: string;
+  data: {
+    entity: TransformedEntityName;
+  };
+};
+
+export function passSignatureToBaseComponent(
+  file: string,
+  options: Options,
+): {
+  interfaceName: string | undefined;
+  newFile: string;
+} {
+  const traverse = AST.traverse(true);
+
+  const { baseComponentName, data } = options;
+  let interfaceName: string | undefined;
+
+  const ast = traverse(file, {
+    visitCallExpression(path) {
+      // @ts-ignore: Assume that types from external packages are correct
+      const calleeName = path.node.callee.name;
+
+      if (calleeName !== baseComponentName) {
+        return false;
+      }
+
+      // @ts-ignore: Assume that types from external packages are correct
+      const typeParameters = path.node.typeParameters;
+
+      // When the interface is missing
+      if (!typeParameters) {
+        if (path.parentPath.node.type !== 'VariableDeclaration') {
+          return false;
+        }
+
+        const index = path.parentPath.parentPath.parentPath.name;
+
+        path.parentPath.parentPath.parentPath.parentPath.value.splice(
+          index,
+          0,
+          AST.builders.tsInterfaceDeclaration(
+            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+            AST.builders.tsInterfaceBody(
+              convertArgsToSignature({
+                b: AST.builders,
+                nodes: [],
+              }),
+            ),
+          ),
+        );
+
+        // @ts-ignore: Assume that types from external packages are correct
+        path.node.typeParameters = AST.builders.tsTypeParameterInstantiation([
+          AST.builders.tsTypeReference(
+            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+          ),
+        ]);
+
+        return false;
+      }
+
+      const typeParameter = typeParameters.params[0]!;
+
+      switch (typeParameter.type) {
+        // When the interface is directly passed to the component
+        case 'TSTypeLiteral': {
+          if (isSignature(typeParameter.members)) {
+            break;
+          }
+
+          const index = path.parentPath.parentPath.parentPath.name;
+
+          path.parentPath.parentPath.parentPath.parentPath.value.splice(
+            index,
+            0,
+            AST.builders.tsInterfaceDeclaration(
+              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+              AST.builders.tsInterfaceBody(
+                convertArgsToSignature({
+                  b: AST.builders,
+                  nodes: typeParameter.members,
+                }),
+              ),
+            ),
+          );
+
+          // @ts-ignore: Assume that types from external packages are correct
+          path.node.typeParameters.params = [
+            AST.builders.tsTypeReference(
+              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+            ),
+          ];
+
+          return false;
+        }
+
+        // When the interface is defined "outside"
+        case 'TSTypeReference': {
+          interfaceName = typeParameter.typeName.name;
+          typeParameter.typeName.name = `${data.entity.classifiedName}Signature`;
+
+          return false;
+        }
+      }
+
+      return false;
+    },
+
+    visitClassDeclaration(path) {
+      // @ts-ignore: Assume that types from external packages are correct
+      if (path.node.superClass.name !== baseComponentName) {
+        return false;
+      }
+
+      const typeParameters = path.node.superTypeParameters;
+
+      // When the interface is missing
+      if (!typeParameters) {
+        if (path.parentPath.node.type !== 'ExportDefaultDeclaration') {
+          return false;
+        }
+
+        const index = path.parentPath.name;
+
+        path.parentPath.parentPath.value.splice(
+          index,
+          0,
+          AST.builders.tsInterfaceDeclaration(
+            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+            AST.builders.tsInterfaceBody(
+              convertArgsToSignature({
+                b: AST.builders,
+                nodes: [],
+              }),
+            ),
+          ),
+        );
+
+        path.node.superTypeParameters =
+          AST.builders.tsTypeParameterInstantiation([
+            AST.builders.tsTypeReference(
+              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+            ),
+          ]);
+
+        return false;
+      }
+
+      const typeParameter = typeParameters.params[0]!;
+
+      switch (typeParameter.type) {
+        // When the interface is directly passed to the component
+        case 'TSTypeLiteral': {
+          if (isSignature(typeParameter.members)) {
+            break;
+          }
+
+          const index = path.parentPath.name;
+
+          path.parentPath.parentPath.value.splice(
+            index,
+            0,
+            AST.builders.tsInterfaceDeclaration(
+              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+              AST.builders.tsInterfaceBody(
+                convertArgsToSignature({
+                  b: AST.builders,
+                  nodes: typeParameter.members,
+                }),
+              ),
+            ),
+          );
+
+          // @ts-ignore: Assume that types from external packages are correct
+          path.node.superTypeParameters.params = [
+            AST.builders.tsTypeReference(
+              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+            ),
+          ];
+
+          return false;
+        }
+
+        // When the interface is defined "outside"
+        case 'TSTypeReference': {
+          // @ts-ignore: Assume that types from external packages are correct
+          interfaceName = typeParameter.typeName.name;
+          // @ts-ignore: Assume that types from external packages are correct
+          typeParameter.typeName.name = `${data.entity.classifiedName}Signature`;
+
+          return false;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  return {
+    interfaceName,
+    newFile: AST.print(ast),
+  };
+}

--- a/src/steps/create-signatures/update-references.ts
+++ b/src/steps/create-signatures/update-references.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { TransformedEntityName } from '../../utils/files.js';
+import { convertArgsToSignature } from './convert-args-to-signature.js';
+import { isSignature } from './is-signature.js';
+
+type Options = {
+  data: {
+    entity: TransformedEntityName;
+  };
+  interfaceName: string;
+};
+
+export function updateReferences(
+  file: string,
+  options: Options,
+): {
+  newFile: string;
+} {
+  const traverse = AST.traverse(true);
+
+  const { interfaceName, data } = options;
+
+  const ast = traverse(file, {
+    visitTSInterfaceDeclaration(path) {
+      // @ts-ignore: Assume that types from external packages are correct
+      if (path.node.id.name !== interfaceName) {
+        return false;
+      }
+
+      // @ts-ignore: Assume that types from external packages are correct
+      path.node.id.name = `${data.entity.classifiedName}Signature`;
+
+      const typeParameter = path.node.body;
+      if (isSignature(typeParameter.body)) {
+        return false;
+      }
+
+      typeParameter.body = convertArgsToSignature({
+        b: AST.builders,
+        nodes: typeParameter.body,
+      });
+
+      return false;
+    },
+
+    visitTSTypeAliasDeclaration(path) {
+      // @ts-ignore: Assume that types from external packages are correct
+      if (path.node.id.name !== interfaceName) {
+        return false;
+      }
+
+      // @ts-ignore: Assume that types from external packages are correct
+      path.node.id.name = `${data.entity.classifiedName}Signature`;
+
+      const typeParameter = path.node.typeAnnotation;
+
+      // @ts-ignore: Assume that types from external packages are correct
+      if (isSignature(typeParameter.members)) {
+        return false;
+      }
+
+      // @ts-ignore: Assume that types from external packages are correct
+      typeParameter.members = convertArgsToSignature({
+        b: AST.builders,
+        // @ts-ignore: Assume that types from external packages are correct
+        nodes: typeParameter.members,
+      });
+
+      return false;
+    },
+
+    visitTSTypeReference(path) {
+      if (path.node.typeName.type !== 'Identifier') {
+        return false;
+      }
+
+      if (path.node.typeName.name !== interfaceName) {
+        return false;
+      }
+
+      if (path.node.typeName.name.endsWith('Signature')) {
+        return false;
+      }
+
+      path.node.typeName.name = `${data.entity.classifiedName}Signature['Args']`;
+
+      return false;
+    },
+  });
+
+  return {
+    newFile: AST.print(ast),
+  };
+}

--- a/src/steps/create-signatures/update-references.ts
+++ b/src/steps/create-signatures/update-references.ts
@@ -37,10 +37,7 @@ export function updateReferences(
         return false;
       }
 
-      typeParameter.body = convertArgsToSignature({
-        b: AST.builders,
-        nodes: typeParameter.body,
-      });
+      typeParameter.body = convertArgsToSignature(typeParameter.body);
 
       return false;
     },
@@ -62,11 +59,7 @@ export function updateReferences(
       }
 
       // @ts-ignore: Assume that types from external packages are correct
-      typeParameter.members = convertArgsToSignature({
-        b: AST.builders,
-        // @ts-ignore: Assume that types from external packages are correct
-        nodes: typeParameter.members,
-      });
+      typeParameter.members = convertArgsToSignature(typeParameter.members);
 
       return false;
     },

--- a/src/steps/create-template-only-components.ts
+++ b/src/steps/create-template-only-components.ts
@@ -13,13 +13,10 @@ const blueprintFile = readFileSync(
   'utf8',
 );
 
-function createBackingClass(entityName: string, options: Options): string {
+function createBackingClass(entityName: string): string {
   const entity = transformEntityName(entityName);
 
-  const file = processTemplate(blueprintFile, {
-    entity,
-    options,
-  });
+  const file = processTemplate(blueprintFile, { entity });
 
   return file;
 }
@@ -38,7 +35,7 @@ export function createTemplateOnlyComponents(
     }
 
     const filePath = getComponentFilePath(options)(entityName);
-    const file = createBackingClass(entityName, options);
+    const file = createBackingClass(entityName);
 
     fileMap.set(filePath, file);
   }


### PR DESCRIPTION
## Description

Currently, the files for `create-signatures` and `create-registries` steps are long and complex.

For this pull request, I extracted functions so that one may be able to understand how `create-signatures` works from the function names. I also simplified the API for a couple of extracted functions.

In a separate pull request, I will add tests for the `create-signatures` step so that we can refactor code further.
