### PR TITLE
Refactored createRegistries

### DIFF
--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -11,31 +11,11 @@ import {
   type TransformedEntityName,
   transformEntityName,
 } from '../utils/files.js';
+import { hasRegistry } from './create-registries/index.js';
 
 type Data = {
   entity: TransformedEntityName;
 };
-
-function hasRegistry(file: string): boolean {
-  const traverse = AST.traverse(true);
-
-  let hasRegistry = false;
-
-  traverse(file, {
-    visitTSModuleDeclaration(path) {
-      // @ts-ignore: Assume that types from external packages are correct
-      const moduleName = path.node.id.value;
-
-      if (moduleName === '@glint/environment-ember-loose/registry') {
-        hasRegistry = true;
-      }
-
-      return false;
-    },
-  });
-
-  return hasRegistry;
-}
 
 function createRegistry(file: string, data: Data): string {
   const traverse = AST.traverse(true);

--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { AST } from '@codemod-utils/ast-javascript';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
@@ -12,6 +10,7 @@ import {
   transformEntityName,
 } from '../utils/files.js';
 import {
+  createRegistry,
   getBaseComponentName,
   hasRegistry,
   passComponentNameToBaseComponent,
@@ -21,52 +20,6 @@ import {
 type Data = {
   entity: TransformedEntityName;
 };
-
-function createRegistry(file: string, data: Data): string {
-  const traverse = AST.traverse(true);
-
-  const ast = traverse(file);
-
-  // @ts-ignore: Assume that types from external packages are correct
-  const nodes = ast.program.body;
-
-  const registryEntries = AST.builders.tsInterfaceBody([
-    AST.builders.tsPropertySignature(
-      AST.builders.stringLiteral(data.entity.doubleColonizedName),
-      AST.builders.tsTypeAnnotation(
-        AST.builders.tsTypeQuery(
-          AST.builders.identifier(`${data.entity.classifiedName}Component`),
-        ),
-      ),
-    ),
-    AST.builders.tsPropertySignature(
-      AST.builders.stringLiteral(data.entity.name),
-      AST.builders.tsTypeAnnotation(
-        AST.builders.tsTypeQuery(
-          AST.builders.identifier(`${data.entity.classifiedName}Component`),
-        ),
-      ),
-    ),
-  ]);
-
-  const registryNode = AST.builders.tsModuleDeclaration(
-    AST.builders.stringLiteral('@glint/environment-ember-loose/registry'),
-    AST.builders.tsModuleBlock([
-      AST.builders.exportDefaultDeclaration(
-        AST.builders.tsInterfaceDeclaration(
-          AST.builders.identifier('Registry'),
-          registryEntries,
-        ),
-      ),
-    ]),
-  );
-
-  registryNode.declare = true;
-
-  nodes.push(registryNode);
-
-  return AST.print(ast);
-}
 
 function renameComponent(file: string, data: Data): string {
   const baseComponentName = getBaseComponentName(file);

--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -4,44 +4,12 @@ import { join } from 'node:path';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
-import {
-  getComponentFilePath,
-  type TransformedEntityName,
-  transformEntityName,
-} from '../utils/files.js';
+import { getComponentFilePath, transformEntityName } from '../utils/files.js';
 import {
   createRegistry,
-  getBaseComponentName,
   hasRegistry,
-  passComponentNameToBaseComponent,
-  updateReferences,
+  renameComponent,
 } from './create-registries/index.js';
-
-type Data = {
-  entity: TransformedEntityName;
-};
-
-function renameComponent(file: string, data: Data): string {
-  const baseComponentName = getBaseComponentName(file);
-
-  if (baseComponentName === undefined) {
-    return file;
-  }
-
-  // eslint-disable-next-line prefer-const
-  let { componentName, newFile } = passComponentNameToBaseComponent(file, {
-    baseComponentName,
-    data,
-  });
-
-  ({ newFile } = updateReferences(newFile, {
-    baseComponentName,
-    componentName,
-    data,
-  }));
-
-  return newFile;
-}
 
 export function createRegistries(context: Context, options: Options): void {
   const { projectRoot } = options;

--- a/src/steps/create-registries/create-registry.ts
+++ b/src/steps/create-registries/create-registry.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { TransformedEntityName } from '../../utils/files.js';
+
+type Data = {
+  entity: TransformedEntityName;
+};
+
+export function createRegistry(file: string, data: Data): string {
+  const traverse = AST.traverse(true);
+
+  const ast = traverse(file);
+
+  // @ts-ignore: Assume that types from external packages are correct
+  const nodes = ast.program.body;
+
+  const registryEntries = AST.builders.tsInterfaceBody([
+    AST.builders.tsPropertySignature(
+      AST.builders.stringLiteral(data.entity.doubleColonizedName),
+      AST.builders.tsTypeAnnotation(
+        AST.builders.tsTypeQuery(
+          AST.builders.identifier(`${data.entity.classifiedName}Component`),
+        ),
+      ),
+    ),
+    AST.builders.tsPropertySignature(
+      AST.builders.stringLiteral(data.entity.name),
+      AST.builders.tsTypeAnnotation(
+        AST.builders.tsTypeQuery(
+          AST.builders.identifier(`${data.entity.classifiedName}Component`),
+        ),
+      ),
+    ),
+  ]);
+
+  const registryNode = AST.builders.tsModuleDeclaration(
+    AST.builders.stringLiteral('@glint/environment-ember-loose/registry'),
+    AST.builders.tsModuleBlock([
+      AST.builders.exportDefaultDeclaration(
+        AST.builders.tsInterfaceDeclaration(
+          AST.builders.identifier('Registry'),
+          registryEntries,
+        ),
+      ),
+    ]),
+  );
+
+  registryNode.declare = true;
+
+  nodes.push(registryNode);
+
+  return AST.print(ast);
+}

--- a/src/steps/create-registries/get-base-component-name.ts
+++ b/src/steps/create-registries/get-base-component-name.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+export function getBaseComponentName(file: string): string | undefined {
+  const traverse = AST.traverse(true);
+
+  let baseComponentName: string | undefined;
+
+  traverse(file, {
+    visitImportDeclaration(path) {
+      const importPath = path.node.source.value;
+
+      switch (importPath) {
+        case '@ember/component/template-only':
+        case '@glimmer/component': {
+          // @ts-ignore: Assume that types from external packages are correct
+          baseComponentName = path.node.specifiers[0]!.local.name;
+
+          return false;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  return baseComponentName;
+}

--- a/src/steps/create-registries/has-registry.ts
+++ b/src/steps/create-registries/has-registry.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+export function hasRegistry(file: string): boolean {
+  const traverse = AST.traverse(true);
+
+  let hasRegistry = false;
+
+  traverse(file, {
+    visitTSModuleDeclaration(path) {
+      // @ts-ignore: Assume that types from external packages are correct
+      const moduleName = path.node.id.value;
+
+      if (moduleName === '@glint/environment-ember-loose/registry') {
+        hasRegistry = true;
+      }
+
+      return false;
+    },
+  });
+
+  return hasRegistry;
+}

--- a/src/steps/create-registries/index.ts
+++ b/src/steps/create-registries/index.ts
@@ -1,0 +1,1 @@
+export * from './has-registry.js';

--- a/src/steps/create-registries/index.ts
+++ b/src/steps/create-registries/index.ts
@@ -1,3 +1,4 @@
 export * from './get-base-component-name.js';
 export * from './has-registry.js';
 export * from './pass-component-name-to-base-component.js';
+export * from './update-references.js';

--- a/src/steps/create-registries/index.ts
+++ b/src/steps/create-registries/index.ts
@@ -1,5 +1,3 @@
 export * from './create-registry.js';
-export * from './get-base-component-name.js';
 export * from './has-registry.js';
-export * from './pass-component-name-to-base-component.js';
-export * from './update-references.js';
+export * from './rename-component.js';

--- a/src/steps/create-registries/index.ts
+++ b/src/steps/create-registries/index.ts
@@ -1,2 +1,3 @@
 export * from './get-base-component-name.js';
 export * from './has-registry.js';
+export * from './pass-component-name-to-base-component.js';

--- a/src/steps/create-registries/index.ts
+++ b/src/steps/create-registries/index.ts
@@ -1,1 +1,2 @@
+export * from './get-base-component-name.js';
 export * from './has-registry.js';

--- a/src/steps/create-registries/index.ts
+++ b/src/steps/create-registries/index.ts
@@ -1,3 +1,4 @@
+export * from './create-registry.js';
 export * from './get-base-component-name.js';
 export * from './has-registry.js';
 export * from './pass-component-name-to-base-component.js';

--- a/src/steps/create-registries/pass-component-name-to-base-component.ts
+++ b/src/steps/create-registries/pass-component-name-to-base-component.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { TransformedEntityName } from '../../utils/files.js';
+
+type Options = {
+  baseComponentName: string;
+  data: {
+    entity: TransformedEntityName;
+  };
+};
+
+export function passComponentNameToBaseComponent(
+  file: string,
+  options: Options,
+): {
+  componentName: string;
+  newFile: string;
+} {
+  const traverse = AST.traverse(true);
+
+  const { baseComponentName, data } = options;
+  let componentName!: string;
+
+  const ast = traverse(file, {
+    visitClassDeclaration(path) {
+      if (!path.node.superClass) {
+        return false;
+      }
+
+      // @ts-ignore: Assume that types from external packages are correct
+      if (path.node.superClass.name !== baseComponentName) {
+        return false;
+      }
+
+      if (!path.node.id) {
+        path.node.id = AST.builders.identifier(
+          `${data.entity.classifiedName}Component`,
+        );
+
+        return false;
+      }
+
+      componentName = path.node.id.name as string;
+      path.node.id.name = `${data.entity.classifiedName}Component`;
+
+      return false;
+    },
+
+    visitVariableDeclaration(path) {
+      const declaration = path.node.declarations[0]!;
+
+      // @ts-ignore: Assume that types from external packages are correct
+      switch (declaration.init.type) {
+        case 'CallExpression': {
+          // @ts-ignore: Assume that types from external packages are correct
+          if (declaration.init.callee.type !== 'Identifier') {
+            return false;
+          }
+
+          // @ts-ignore: Assume that types from external packages are correct
+          if (declaration.init.callee.name !== baseComponentName) {
+            return false;
+          }
+
+          // @ts-ignore: Assume that types from external packages are correct
+          componentName = declaration.id.name;
+          // @ts-ignore: Assume that types from external packages are correct
+          declaration.id.name = `${data.entity.classifiedName}Component`;
+
+          return false;
+        }
+
+        case 'ClassExpression': {
+          // @ts-ignore: Assume that types from external packages are correct
+          if (!declaration.init.superClass) {
+            return false;
+          }
+
+          // @ts-ignore: Assume that types from external packages are correct
+          if (declaration.init.superClass.name !== baseComponentName) {
+            return false;
+          }
+
+          // @ts-ignore: Assume that types from external packages are correct
+          componentName = declaration.id.name;
+          // @ts-ignore: Assume that types from external packages are correct
+          declaration.id.name = `${data.entity.classifiedName}Component`;
+
+          return false;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  return {
+    componentName,
+    newFile: AST.print(ast),
+  };
+}

--- a/src/steps/create-registries/rename-component.ts
+++ b/src/steps/create-registries/rename-component.ts
@@ -1,0 +1,30 @@
+import type { TransformedEntityName } from '../../utils/files.js';
+import { getBaseComponentName } from './get-base-component-name.js';
+import { passComponentNameToBaseComponent } from './pass-component-name-to-base-component.js';
+import { updateReferences } from './update-references.js';
+
+type Data = {
+  entity: TransformedEntityName;
+};
+
+export function renameComponent(file: string, data: Data): string {
+  const baseComponentName = getBaseComponentName(file);
+
+  if (baseComponentName === undefined) {
+    return file;
+  }
+
+  // eslint-disable-next-line prefer-const
+  let { componentName, newFile } = passComponentNameToBaseComponent(file, {
+    baseComponentName,
+    data,
+  });
+
+  ({ newFile } = updateReferences(newFile, {
+    baseComponentName,
+    componentName,
+    data,
+  }));
+
+  return newFile;
+}

--- a/src/steps/create-registries/update-references.ts
+++ b/src/steps/create-registries/update-references.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { TransformedEntityName } from '../../utils/files.js';
+
+type Options = {
+  baseComponentName: string;
+  componentName: string;
+  data: {
+    entity: TransformedEntityName;
+  };
+};
+
+export function updateReferences(
+  file: string,
+  options: Options,
+): {
+  newFile: string;
+} {
+  const traverse = AST.traverse(true);
+
+  const { baseComponentName, componentName, data } = options;
+
+  const ast = traverse(file, {
+    visitExportDefaultDeclaration(path) {
+      switch (path.node.declaration.type) {
+        case 'CallExpression': {
+          // @ts-ignore: Assume that types from external packages are correct
+          if (path.node.declaration.callee.name !== baseComponentName) {
+            return false;
+          }
+
+          const nodesToAdd = [
+            AST.builders.noop(),
+            AST.builders.exportDefaultDeclaration(
+              AST.builders.identifier(`${data.entity.classifiedName}Component`),
+            ),
+          ];
+
+          path.parentPath.value.push(...nodesToAdd);
+
+          return AST.builders.variableDeclaration('const', [
+            AST.builders.variableDeclarator(
+              AST.builders.identifier(`${data.entity.classifiedName}Component`),
+              path.node.declaration,
+            ),
+          ]);
+        }
+
+        case 'Identifier': {
+          if (path.node.declaration.name !== componentName) {
+            return false;
+          }
+
+          path.node.declaration.name = `${data.entity.classifiedName}Component`;
+
+          return false;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  return {
+    newFile: AST.print(ast),
+  };
+}


### PR DESCRIPTION
## Description

A continuation of #8.

For this pull request, I extracted functions so that one may be able to understand how `create-registries` works from the function names. I also simplified the API for a couple of extracted functions.

In a separate pull request, I will add tests for the `create-registries` step so that we can refactor code further.
