### PR TITLE
Added tests for create-signatures

### DIFF
--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -4,45 +4,8 @@ import { join } from 'node:path';
 import { createFiles } from '@codemod-utils/files';
 
 import type { Context, Options } from '../types/index.js';
-import {
-  getComponentFilePath,
-  type TransformedEntityName,
-  transformEntityName,
-} from '../utils/files.js';
-import {
-  getBaseComponentName,
-  passSignatureToBaseComponent,
-  updateReferences,
-} from './create-signatures/index.js';
-
-type Data = {
-  entity: TransformedEntityName;
-};
-
-function createSignature(file: string, data: Data): string {
-  const baseComponentName = getBaseComponentName(file);
-
-  if (baseComponentName === undefined) {
-    return file;
-  }
-
-  // eslint-disable-next-line prefer-const
-  let { interfaceName, newFile } = passSignatureToBaseComponent(file, {
-    baseComponentName,
-    data,
-  });
-
-  if (interfaceName === undefined) {
-    return newFile;
-  }
-
-  ({ newFile } = updateReferences(newFile, {
-    data,
-    interfaceName,
-  }));
-
-  return newFile;
-}
+import { getComponentFilePath, transformEntityName } from '../utils/files.js';
+import { createSignature } from './create-signatures/index.js';
 
 export function createSignatures(context: Context, options: Options): void {
   const { projectRoot } = options;

--- a/src/steps/create-signatures/create-signature.ts
+++ b/src/steps/create-signatures/create-signature.ts
@@ -1,6 +1,7 @@
 import type { TransformedEntityName } from '../../utils/files.js';
 import { getBaseComponentName } from './get-base-component-name.js';
 import { passSignatureToBaseComponent } from './pass-signature-to-base-component.js';
+import { updateConstructor } from './update-constructor.js';
 import { updateReferences } from './update-references.js';
 
 type Data = {
@@ -19,6 +20,10 @@ export function createSignature(file: string, data: Data): string {
     baseComponentName,
     data,
   });
+
+  ({ newFile } = updateConstructor(newFile, {
+    data,
+  }));
 
   if (interfaceName === undefined) {
     return newFile;

--- a/src/steps/create-signatures/create-signature.ts
+++ b/src/steps/create-signatures/create-signature.ts
@@ -1,0 +1,33 @@
+import type { TransformedEntityName } from '../../utils/files.js';
+import { getBaseComponentName } from './get-base-component-name.js';
+import { passSignatureToBaseComponent } from './pass-signature-to-base-component.js';
+import { updateReferences } from './update-references.js';
+
+type Data = {
+  entity: TransformedEntityName;
+};
+
+export function createSignature(file: string, data: Data): string {
+  const baseComponentName = getBaseComponentName(file);
+
+  if (baseComponentName === undefined) {
+    return file;
+  }
+
+  // eslint-disable-next-line prefer-const
+  let { interfaceName, newFile } = passSignatureToBaseComponent(file, {
+    baseComponentName,
+    data,
+  });
+
+  if (interfaceName === undefined) {
+    return newFile;
+  }
+
+  ({ newFile } = updateReferences(newFile, {
+    data,
+    interfaceName,
+  }));
+
+  return newFile;
+}

--- a/src/steps/create-signatures/index.ts
+++ b/src/steps/create-signatures/index.ts
@@ -1,3 +1,1 @@
-export * from './get-base-component-name.js';
-export * from './pass-signature-to-base-component.js';
-export * from './update-references.js';
+export * from './create-signature.js';

--- a/src/steps/create-signatures/update-constructor.ts
+++ b/src/steps/create-signatures/update-constructor.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { TransformedEntityName } from '../../utils/files.js';
+
+type Options = {
+  data: {
+    entity: TransformedEntityName;
+  };
+};
+
+export function updateConstructor(
+  file: string,
+  options: Options,
+): {
+  newFile: string;
+} {
+  const traverse = AST.traverse(true);
+
+  const { data } = options;
+
+  const ast = traverse(file, {
+    visitClassMethod(path) {
+      if (path.node.kind !== 'constructor') {
+        return false;
+      }
+
+      if (path.node.params.length !== 2) {
+        return false;
+      }
+
+      const args = path.node.params[1];
+
+      // @ts-ignore: Assume that types from external packages are correct
+      args.typeAnnotation = AST.builders.tsTypeAnnotation(
+        AST.builders.tsIndexedAccessType(
+          AST.builders.tsTypeReference(
+            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+          ),
+          AST.builders.tsLiteralType(AST.builders.stringLiteral('Args')),
+        ),
+      );
+
+      return false;
+    },
+  });
+
+  return {
+    newFile: AST.print(ast),
+  };
+}

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-2.ts
@@ -16,7 +16,7 @@ export default class WidgetsWidget2Component extends Component<WidgetsWidget2Sig
   @tracked data = [] as Data[];
   @tracked summaries = [] as Summary[];
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-2/index.ts
@@ -16,7 +16,7 @@ export default class WidgetsWidget2Component extends Component<WidgetsWidget2Sig
   @tracked data = [] as Data[];
   @tracked summaries = [] as Summary[];
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3.ts
@@ -11,7 +11,7 @@ interface WidgetsWidget3Signature {
 export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   @tracked concertData = {} as Concert;
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-2.ts
@@ -16,7 +16,7 @@ export default class WidgetsWidget2Component extends Component<WidgetsWidget2Sig
   @tracked data = [] as Data[];
   @tracked summaries = [] as Summary[];
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}}>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/navigation-menu.ts
@@ -1,0 +1,15 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type MenuItem = {
+  label: string;
+  route: string;
+};
+
+interface Args {
+  menuItems: MenuItem[];
+  name?: string;
+}
+
+const NavigationMenu = templateOnlyComponent<Args>();
+
+export default NavigationMenu;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/card.ts
@@ -1,0 +1,10 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+import type { Product } from '../../../data/products';
+
+const Component = templateOnlyComponent<{
+  product: Product;
+  redirectTo?: string;
+}>();
+
+export default Component;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/products/product/image.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageArgs {
+  src: string;
+}
+
+class ProductsProductImage extends Component<ProductsProductImageArgs> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/tracks/list.hbs
@@ -1,0 +1,31 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/tracks/list.ts
@@ -1,0 +1,26 @@
+import Component from '@glimmer/component';
+
+import type { Track } from '../../data/album';
+
+type Args = {
+  numColumns?: number;
+  tracks?: Track[];
+};
+
+export default class TracksListComponent extends Component<Args> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form.ts
@@ -1,0 +1,29 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormComponentArgs {
+  data?: Record<string, any>;
+  instructions?: string;
+  title?: string;
+}
+
+export default class UiFormComponent extends Component<UiFormComponentArgs> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/checkbox.ts
@@ -1,0 +1,51 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface CheckboxArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isInline?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+}
+
+export default class UiFormCheckboxComponent extends Component<CheckboxArgs> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/field.ts
@@ -1,0 +1,12 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldComponentArgs {
+  errorMessage?: string;
+  isInline?: boolean;
+  isWide?: boolean;
+}
+
+export default class extends Component<UiFormFieldComponentArgs> {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/input.ts
@@ -1,0 +1,48 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface InputComponentArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  placeholder?: string;
+  type?: string;
+}
+
+export default class UiFormInputComponent extends Component<InputComponentArgs> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/form/textarea.ts
@@ -1,0 +1,43 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface TextareaComponentArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  placeholder?: string;
+}
+
+export default class UiFormTextareaComponent extends Component<TextareaComponentArgs> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/ui/page.ts
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+interface UiPageComponentArgs {
+  title: string;
+}
+
+export default class UiPageComponent extends Component<UiPageComponentArgs> {}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent<{}>();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+export default class WidgetsWidget2Component extends Component<{}> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+export default class extends Component<{ summaries?: Summary[]; }> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2StackedChartArgs {
+  data: Data[];
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartArgs> {}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3.ts
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Args {}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Args> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Args) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,21 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface ResponsiveImageArgs {
+  images: Image[];
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<ResponsiveImageArgs> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args as ResponsiveImageArgs;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4.ts
@@ -1,0 +1,7 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type WidgetsWidget4Args = {};
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Args>();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,7 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface Args {}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<Args>();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,8 @@
+import templateOnlyComponent from '@ember/component/template-only';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoActionsArgs {
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}
+
+export default templateOnlyComponent<WidgetsWidget4MemoActionsArgs>();

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Body = class extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Body;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Header = class FooComponent extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Header;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}}>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/navigation-menu.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type MenuItem = {
+  label: string;
+  route: string;
+};
+
+interface NavigationMenuSignature {
+  Args: {
+    menuItems: MenuItem[];
+    name?: string;
+  };
+}
+
+const NavigationMenu = templateOnlyComponent<NavigationMenuSignature>();
+
+export default NavigationMenu;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/card.ts
@@ -1,0 +1,14 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+import type { Product } from '../../../data/products';
+
+interface ProductsProductCardSignature {
+  Args: {
+    product: Product;
+    redirectTo?: string;
+  };
+}
+
+const Component = templateOnlyComponent<ProductsProductCardSignature>();
+
+export default Component;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/products/product/image.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageSignature {
+  Args: {
+    src: string;
+  }
+}
+
+class ProductsProductImage extends Component<ProductsProductImageSignature> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/tracks/list.hbs
@@ -1,0 +1,31 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/tracks/list.ts
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+
+import type { Track } from '../../data/album';
+
+type TracksListSignature = {
+  Args: {
+    numColumns?: number;
+    tracks?: Track[];
+  };
+};
+
+export default class TracksListComponent extends Component<TracksListSignature> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form.ts
@@ -1,0 +1,31 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormSignature {
+  Args: {
+    data?: Record<string, any>;
+    instructions?: string;
+    title?: string;
+  };
+}
+
+export default class UiFormComponent extends Component<UiFormSignature> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/checkbox.ts
@@ -1,0 +1,53 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormCheckboxSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isInline?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  };
+}
+
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/field.ts
@@ -1,0 +1,14 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldSignature {
+  Args: {
+    errorMessage?: string;
+    isInline?: boolean;
+    isWide?: boolean;
+  };
+}
+
+export default class extends Component<UiFormFieldSignature> {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/input.ts
@@ -1,0 +1,50 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormInputSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+    placeholder?: string;
+    type?: string;
+  };
+}
+
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/form/textarea.ts
@@ -1,0 +1,45 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormTextareaSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+    placeholder?: string;
+  };
+}
+
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/ui/page.ts
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+interface UiPageSignature {
+  Args: {
+    title: string;
+  }
+}
+
+export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-1.ts
@@ -1,0 +1,9 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2.ts
@@ -16,7 +16,7 @@ export default class WidgetsWidget2Component extends Component<WidgetsWidget2Sig
   @tracked data = [] as Data[];
   @tracked summaries = [] as Summary[];
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2.ts
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,53 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+interface WidgetsWidget2CaptionsSignature {
+  Args: {
+    summaries?: Summary[];
+  };
+}
+
+export default class extends Component<WidgetsWidget2CaptionsSignature> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2StackedChartSignature {
+  Args: {
+    data: Data[];
+  }
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3.ts
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,23 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
+  Args: {
+    images: Image[];
+  }
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args as WidgetsWidget3TourScheduleResponsiveImageSignature['Args'];
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4.ts
@@ -1,0 +1,9 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type WidgetsWidget4Signature = {
+  Args: {};
+};
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,9 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,10 @@
+import templateOnlyComponent from '@ember/component/template-only';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  }
+}
+
+export default templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Body = class extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Body;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Header = class FooComponent extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Header;

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.d.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.d.ts
@@ -1,0 +1,5 @@
+import type { Track } from '../data/album';
+
+export interface TracksComponentArgs {
+  tracks?: Array<Track>;
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface TracksSignature {
+  Args: {};
+}
+
+const TracksComponent =
+  templateOnlyComponent<TracksSignature>();
+
+export default TracksComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks': typeof TracksComponent;
+    'tracks': typeof TracksComponent;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.d.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.d.ts
@@ -1,0 +1,5 @@
+import type { Concert } from '../../../data/concert';
+
+export interface WidgetsWidget3TourScheduleComponentArgs {
+  concert: Concert;
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.hbs
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.hbs
@@ -1,0 +1,31 @@
+<ContainerQuery
+  @features={{hash small=(width max=400)}}
+  @dataAttributePrefix="cq"
+  local-class="container"
+>
+  <div local-class="splash">
+    <div local-class="splash-image-container">
+      {{#if @concert.images}}
+        <WidgetsWidget3TourScheduleResponsiveImage
+          @images={{@concert.images}}
+        />
+
+      {{else}}
+        <div local-class="placeholder-image"></div>
+
+      {{/if}}
+    </div>
+
+    <div local-class="concert-date-container">
+      <time local-class="concert-date">
+        {{@concert.date}}
+      </time>
+    </div>
+
+    <div local-class="venue-name-container">
+      <a href="#" local-class="concert-link">
+        <div local-class="venue-name">{{@concert.name}}</div>
+      </a>
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget3TourScheduleSignature {
+  Args: {};
+}
+
+const WidgetsWidget3TourScheduleComponent =
+  templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
+
+export default WidgetsWidget3TourScheduleComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
+    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.d.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.d.ts
@@ -1,0 +1,5 @@
+import type { Track } from '../data/album';
+
+export interface TracksComponentArgs {
+  tracks?: Array<Track>;
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface TracksSignature {
+  Args: {};
+}
+
+const TracksComponent =
+  templateOnlyComponent<TracksSignature>();
+
+export default TracksComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks': typeof TracksComponent;
+    'tracks': typeof TracksComponent;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.d.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.d.ts
@@ -1,0 +1,5 @@
+import type { Concert } from '../../../data/concert';
+
+export interface WidgetsWidget3TourScheduleComponentArgs {
+  concert: Concert;
+}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.hbs
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.hbs
@@ -1,0 +1,31 @@
+<ContainerQuery
+  @features={{hash small=(width max=400)}}
+  @dataAttributePrefix="cq"
+  local-class="container"
+>
+  <div local-class="splash">
+    <div local-class="splash-image-container">
+      {{#if @concert.images}}
+        <WidgetsWidget3TourScheduleResponsiveImage
+          @images={{@concert.images}}
+        />
+
+      {{else}}
+        <div local-class="placeholder-image"></div>
+
+      {{/if}}
+    </div>
+
+    <div local-class="concert-date-container">
+      <time local-class="concert-date">
+        {{@concert.date}}
+      </time>
+    </div>
+
+    <div local-class="venue-name-container">
+      <a href="#" local-class="concert-link">
+        <div local-class="venue-name">{{@concert.name}}</div>
+      </a>
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget3TourScheduleSignature {
+  Args: {};
+}
+
+const WidgetsWidget3TourScheduleComponent =
+  templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
+
+export default WidgetsWidget3TourScheduleComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
+    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/ui/form/information.hbs
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/ui/form/information.hbs
@@ -1,0 +1,23 @@
+{{#if (strict-or @title @instructions)}}
+  <div local-class="container">
+    {{#if @title}}
+      <div
+        data-test-title
+        id={{concat @formId "-title"}}
+        local-class="title"
+      >
+        {{@title}}
+      </div>
+    {{/if}}
+
+    {{#if @instructions}}
+      <p
+        data-test-instructions
+        id={{concat @formId "-instructions"}}
+        local-class="instructions"
+      >
+        {{@instructions}}
+      </p>
+    {{/if}}
+  </div>
+{{/if}}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/ui/form/information.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface UiFormInformationSignature {
+  Args: {};
+}
+
+const UiFormInformationComponent =
+  templateOnlyComponent<UiFormInformationSignature>();
+
+export default UiFormInformationComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Information': typeof UiFormInformationComponent;
+    'ui/form/information': typeof UiFormInformationComponent;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.hbs
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.hbs
@@ -1,0 +1,34 @@
+<ContainerQuery
+  @features={{hash
+    large=(cq-width min=224)
+    tall=(cq-height min=120)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  {{#let
+    (strict-and CQ.features.large CQ.features.tall)
+    as |showFullText|
+  }}
+    <div data-test-call-to-action local-class="call-to-action">
+      {{#if showFullText}}
+        <p>What will <em>you</em> create with</p>
+      {{/if}}
+
+      <p local-class="highlight">
+        <a
+          href="https://github.com/ijlee2/ember-container-query"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ember-container-query
+        </a>
+      </p>
+
+      {{#if showFullText}}
+        <p>?</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget5Signature {
+  Args: {};
+}
+
+const WidgetsWidget5Component =
+  templateOnlyComponent<WidgetsWidget5Signature>();
+
+export default WidgetsWidget5Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget5': typeof WidgetsWidget5Component;
+    'widgets/widget-5': typeof WidgetsWidget5Component;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/ui/form/information.hbs
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/ui/form/information.hbs
@@ -1,0 +1,23 @@
+{{#if (strict-or @title @instructions)}}
+  <div local-class="container">
+    {{#if @title}}
+      <div
+        data-test-title
+        id={{concat @formId "-title"}}
+        local-class="title"
+      >
+        {{@title}}
+      </div>
+    {{/if}}
+
+    {{#if @instructions}}
+      <p
+        data-test-instructions
+        id={{concat @formId "-instructions"}}
+        local-class="instructions"
+      >
+        {{@instructions}}
+      </p>
+    {{/if}}
+  </div>
+{{/if}}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface UiFormInformationSignature {
+  Args: {};
+}
+
+const UiFormInformationComponent =
+  templateOnlyComponent<UiFormInformationSignature>();
+
+export default UiFormInformationComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Information': typeof UiFormInformationComponent;
+    'ui/form/information': typeof UiFormInformationComponent;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.hbs
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.hbs
@@ -1,0 +1,34 @@
+<ContainerQuery
+  @features={{hash
+    large=(cq-width min=224)
+    tall=(cq-height min=120)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  {{#let
+    (strict-and CQ.features.large CQ.features.tall)
+    as |showFullText|
+  }}
+    <div data-test-call-to-action local-class="call-to-action">
+      {{#if showFullText}}
+        <p>What will <em>you</em> create with</p>
+      {{/if}}
+
+      <p local-class="highlight">
+        <a
+          href="https://github.com/ijlee2/ember-container-query"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ember-container-query
+        </a>
+      </p>
+
+      {{#if showFullText}}
+        <p>?</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget5Signature {
+  Args: {};
+}
+
+const WidgetsWidget5Component =
+  templateOnlyComponent<WidgetsWidget5Signature>();
+
+export default WidgetsWidget5Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget5': typeof WidgetsWidget5Component;
+    'widgets/widget-5': typeof WidgetsWidget5Component;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}}>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/navigation-menu.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const NavigationMenu = templateOnlyComponent();
+
+export default NavigationMenu;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/card.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const Component = templateOnlyComponent();
+
+export default Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/products/product/image.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+class ProductsProductImage extends Component {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class TracksComponent extends Component {}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks/list.hbs
@@ -1,0 +1,31 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks/list.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+export default class TracksListComponent extends Component {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form.ts
@@ -1,0 +1,23 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class UiFormComponent extends Component {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/checkbox.ts
@@ -1,0 +1,39 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormCheckboxComponent extends Component {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/field.ts
@@ -1,0 +1,6 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/input.ts
@@ -1,0 +1,35 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormInputComponent extends Component {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/form/textarea.ts
@@ -1,0 +1,31 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormTextareaComponent extends Component {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/ui/page.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class UiPageComponent extends Component {}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+export default class WidgetsWidget2Component extends Component {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+export default class extends Component {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class WidgetsWidget2StackedChartComponent extends Component {}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+export default class WidgetsWidget3Component extends Component {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4Component = templateOnlyComponent();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,3 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+export default templateOnlyComponent();

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Body = class extends Component {}
+
+export default Body;

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Header = class FooComponent extends Component {}
+
+export default Header;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}}>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/navigation-menu.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const NavigationMenu = templateOnlyComponent();
+
+export default NavigationMenu;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/card.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const Component = templateOnlyComponent();
+
+export default Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/image.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+class ProductsProductImage extends Component {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks.ts
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+interface TracksSignature {
+  Args: {};
+}
+
+export default class TracksComponent extends Component<TracksSignature> {}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks/list.hbs
@@ -1,0 +1,31 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks/list.ts
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+
+interface TracksListSignature {
+  Args: {};
+}
+
+export default class TracksListComponent extends Component<TracksListSignature> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form.ts
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormSignature {
+  Args: {};
+}
+
+export default class UiFormComponent extends Component<UiFormSignature> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
@@ -1,0 +1,43 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormCheckboxSignature {
+  Args: {};
+}
+
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/field.ts
@@ -1,0 +1,10 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldSignature {
+  Args: {};
+}
+
+export default class extends Component<UiFormFieldSignature> {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/input.ts
@@ -1,0 +1,39 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormInputSignature {
+  Args: {};
+}
+
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/form/textarea.ts
@@ -1,0 +1,35 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormTextareaSignature {
+  Args: {};
+}
+
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/ui/page.ts
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+interface UiPageSignature {
+  Args: {};
+}
+
+export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2.ts
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,51 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+interface WidgetsWidget2CaptionsSignature {
+  Args: {};
+}
+
+export default class extends Component<WidgetsWidget2CaptionsSignature> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget2StackedChartSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3.ts
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3.ts
@@ -11,7 +11,7 @@ interface WidgetsWidget3Signature {
 export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   @tracked concertData = {} as Concert;
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,20 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4Component = templateOnlyComponent();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,3 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+export default templateOnlyComponent();

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Body = class extends Component {}
+
+export default Body;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Header = class FooComponent extends Component {}
+
+export default Header;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}}>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/navigation-menu.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const NavigationMenu = templateOnlyComponent();
+
+export default NavigationMenu;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks/list.hbs
@@ -1,0 +1,31 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks/list.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+export default class TracksListComponent extends Component {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}}>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/navigation-menu.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const NavigationMenu = templateOnlyComponent();
+
+export default NavigationMenu;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks/list.hbs
@@ -1,0 +1,31 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks/list.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+export default class TracksListComponent extends Component {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}

--- a/tests/steps/create-signatures/has-backing-class.test.ts
+++ b/tests/steps/create-signatures/has-backing-class.test.ts
@@ -23,7 +23,29 @@ test('steps | create-signatures > has-backing-class', function () {
   const context = {
     entities: new Map([
       ['navigation-menu', new Set(['.hbs', '.ts'])],
+      ['products/product/card', new Set(['.hbs', '.ts'])],
+      ['products/product/image', new Set(['.hbs', '.ts'])],
       ['tracks/list', new Set(['.hbs', '.ts'])],
+      ['ui/form', new Set(['.hbs', '.ts'])],
+      ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
+      ['ui/form/field', new Set(['.hbs', '.ts'])],
+      ['ui/form/input', new Set(['.hbs', '.ts'])],
+      ['ui/form/textarea', new Set(['.hbs', '.ts'])],
+      ['ui/page', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-1', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-2', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-3', new Set(['.hbs', '.ts'])],
+      [
+        'widgets/widget-3/tour-schedule/responsive-image',
+        new Set(['.hbs', '.ts']),
+      ],
+      ['widgets/widget-4', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ]),
   };
 

--- a/tests/steps/create-signatures/has-backing-class.test.ts
+++ b/tests/steps/create-signatures/has-backing-class.test.ts
@@ -1,0 +1,35 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { createSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-container-query.js';
+
+test('steps | create-signatures > has-backing-class', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/create-signatures/has-backing-class/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/create-signatures/has-backing-class/output',
+  );
+
+  const context = {
+    entities: new Map([
+      ['navigation-menu', new Set(['.hbs', '.ts'])],
+      ['tracks/list', new Set(['.hbs', '.ts'])],
+    ]),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  createSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/create-signatures/has-declaration-file.test.ts
+++ b/tests/steps/create-signatures/has-declaration-file.test.ts
@@ -1,0 +1,35 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { createSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-container-query.js';
+
+test('steps | create-signatures > has-declaration-file', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/create-signatures/has-declaration-file/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/create-signatures/has-declaration-file/output',
+  );
+
+  const context = {
+    entities: new Map([
+      ['tracks', new Set(['.d.ts', '.hbs'])],
+      ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
+    ]),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  createSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/create-signatures/has-hbs-file-only.test.ts
+++ b/tests/steps/create-signatures/has-hbs-file-only.test.ts
@@ -1,0 +1,35 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { createSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-container-query.js';
+
+test('steps | create-signatures > has-hbs-file-only', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/create-signatures/has-hbs-file-only/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/create-signatures/has-hbs-file-only/output',
+  );
+
+  const context = {
+    entities: new Map([
+      ['ui/form/information', new Set(['.hbs'])],
+      ['widgets/widget-5', new Set(['.hbs'])],
+    ]),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  createSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/create-signatures/has-no-args.test.ts
+++ b/tests/steps/create-signatures/has-no-args.test.ts
@@ -1,0 +1,58 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { createSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-container-query-no-args.js';
+
+test('steps | create-signatures > has-no-args', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/create-signatures/has-no-args/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/create-signatures/has-no-args/output',
+  );
+
+  const context = {
+    entities: new Map([
+      ['navigation-menu', new Set(['.hbs', '.ts'])],
+      ['products/product/card', new Set(['.hbs', '.ts'])],
+      ['products/product/image', new Set(['.hbs', '.ts'])],
+      ['tracks', new Set(['.hbs', '.ts'])],
+      ['tracks/list', new Set(['.hbs', '.ts'])],
+      ['ui/form', new Set(['.hbs', '.ts'])],
+      ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
+      ['ui/form/field', new Set(['.hbs', '.ts'])],
+      ['ui/form/input', new Set(['.hbs', '.ts'])],
+      ['ui/form/textarea', new Set(['.hbs', '.ts'])],
+      ['ui/page', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-1', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-2', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-3', new Set(['.hbs', '.ts'])],
+      [
+        'widgets/widget-3/tour-schedule/responsive-image',
+        new Set(['.hbs', '.ts']),
+      ],
+      ['widgets/widget-4', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
+      ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
+    ]),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  createSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/create-template-only-components/has-no-args.test.ts
+++ b/tests/steps/create-template-only-components/has-no-args.test.ts
@@ -1,0 +1,35 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-container-query-no-args.js';
+
+test('steps | create-template-only-components > has-no-args', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/create-template-only-components/has-no-args/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/create-template-only-components/has-no-args/output',
+  );
+
+  const context = {
+    entities: new Map([
+      ['navigation-menu', new Set(['.hbs', '.ts'])],
+      ['tracks/list', new Set(['.hbs', '.ts'])],
+    ]),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  createTemplateOnlyComponents(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});


### PR DESCRIPTION
## Description

In addition to adding "integration" tests for the `create-signatures` step, I fixed a "bug" (the meaning is technically correct, but the syntax is not ideal).

Before, the constructor `args`'s type could remain unchanged. Now, the `args`'s type is derived from the signature.

```ts
/* Before: After completing the `create-signatures` step */
interface WidgetsWidget2Signature {
  Args: {};
}

export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
  constructor(owner: unknown, args: {}) {
    // ...
  }
}
```

```ts
/* Now: After completing the `create-signatures` step */
interface WidgetsWidget2Signature {
  Args: {};
}

export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
    // ...
  }
}
```
