### PR TITLE
Standardized the signature

### DIFF
--- a/src/steps/create-signatures/update-references.ts
+++ b/src/steps/create-signatures/update-references.ts
@@ -32,6 +32,7 @@ export function updateReferences(
       path.node.id.name = `${data.entity.classifiedName}Signature`;
 
       const typeParameter = path.node.body;
+
       if (isSignature(typeParameter.body)) {
         return false;
       }
@@ -48,19 +49,13 @@ export function updateReferences(
       }
 
       // @ts-ignore: Assume that types from external packages are correct
-      path.node.id.name = `${data.entity.classifiedName}Signature`;
+      const nodes = path.node.typeAnnotation.members;
+      const body = isSignature(nodes) ? nodes : convertArgsToSignature(nodes);
 
-      const typeParameter = path.node.typeAnnotation;
-
-      // @ts-ignore: Assume that types from external packages are correct
-      if (isSignature(typeParameter.members)) {
-        return false;
-      }
-
-      // @ts-ignore: Assume that types from external packages are correct
-      typeParameter.members = convertArgsToSignature(typeParameter.members);
-
-      return false;
+      return AST.builders.tsInterfaceDeclaration(
+        AST.builders.identifier(`${data.entity.classifiedName}Signature`),
+        AST.builders.tsInterfaceBody(body),
+      );
     },
 
     visitTSTypeReference(path) {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/list.ts
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../data/album';
 
-type TracksListSignature = {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
-};
+}
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4.ts
@@ -1,8 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-type WidgetsWidget4Signature = {
+interface WidgetsWidget4Signature {
   Args: {};
-};
+}
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo/body.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoBodyComponent = class extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-4/memo/header.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.ts
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../../data/album';
 
-type TracksListSignature = {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
-};
+}
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/index.ts
@@ -1,8 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-type WidgetsWidget4Signature = {
+interface WidgetsWidget4Signature {
   Args: {};
-};
+}
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/body/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/body/index.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoBodyComponent = class extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/header/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-4/memo/header/index.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 
-const WidgetsWidget4MemoBodyComponent = class extends Component {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 
-const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/tests/fixtures/ember-container-query/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks/list.ts
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../data/album';
 
-type TracksListSignature = {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
-};
+}
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4.ts
@@ -1,8 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-type WidgetsWidget4Signature = {
+interface WidgetsWidget4Signature {
   Args: {};
-};
+}
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoBodyComponent = class extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/tracks/list.ts
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../data/album';
 
-type TracksListSignature = {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
-};
+}
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4.ts
@@ -1,8 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-type WidgetsWidget4Signature = {
+interface WidgetsWidget4Signature {
   Args: {};
-};
+}
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,8 +1,12 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const Body = class extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const Body = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default Body;

--- a/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,8 +1,12 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const Header = class FooComponent extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const Header = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default Header;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,5 +1,9 @@
 import Component from '@glimmer/component';
 
-const Body = class extends Component {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {};
+}
+
+const Body = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default Body;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,5 +1,9 @@
 import Component from '@glimmer/component';
 
-const Header = class FooComponent extends Component {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {};
+}
+
+const Header = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default Header;


### PR DESCRIPTION
## Description

Closes #12.

We can simplify filling out `Args`, `Blocks`, and `Element`, when the codemod has standardized the signature's node type and location (i.e. when filling out the signature, we only need 1 visitor type instead of a few):

- Always write `interface Signature {}` instead of `type Signature = {}`
- Define the signature before passing it to the component (via [generics](https://www.typescriptlang.org/docs/handbook/2/generics.html))

<details>

<summary>Example</summary>

```ts
/* Before */
type TracksListSignature = {
  Args: {
    numColumns?: number;
    tracks?: Track[];
  };
};
```

```ts
/* After */
interface TracksListSignature {
  Args: {
    numColumns?: number;
    tracks?: Track[];
  };
}
```

</details>

Note, changing `type` to `interface` may cause a regression in the consuming project, if the project had extended a component's signature in another component (i.e. the syntax for extending `type` and for extending `interface` differ). To my knowledge, it is not recommended (by Glint) to define a signature with the `type` keyword.
