### PR TITLE
Addressed edge cases

### DIFF
--- a/src/steps/create-signatures/pass-signature-to-base-component.ts
+++ b/src/steps/create-signatures/pass-signature-to-base-component.ts
@@ -37,27 +37,61 @@ export function passSignatureToBaseComponent(
 
       // When the interface is missing
       if (!typeParameters) {
-        if (path.parentPath.node.type !== 'VariableDeclaration') {
-          return false;
+        switch (path.parentPath.node.type) {
+          case 'ExportDefaultDeclaration': {
+            const index = path.parentPath.name;
+
+            path.parentPath.parentPath.value.splice(
+              index,
+              0,
+              AST.builders.tsInterfaceDeclaration(
+                AST.builders.identifier(
+                  `${data.entity.classifiedName}Signature`,
+                ),
+                AST.builders.tsInterfaceBody(convertArgsToSignature([])),
+              ),
+            );
+
+            // @ts-ignore: Assume that types from external packages are correct
+            path.node.typeParameters =
+              AST.builders.tsTypeParameterInstantiation([
+                AST.builders.tsTypeReference(
+                  AST.builders.identifier(
+                    `${data.entity.classifiedName}Signature`,
+                  ),
+                ),
+              ]);
+
+            break;
+          }
+
+          case 'VariableDeclarator': {
+            const index = path.parentPath.parentPath.parentPath.name;
+
+            path.parentPath.parentPath.parentPath.parentPath.value.splice(
+              index,
+              0,
+              AST.builders.tsInterfaceDeclaration(
+                AST.builders.identifier(
+                  `${data.entity.classifiedName}Signature`,
+                ),
+                AST.builders.tsInterfaceBody(convertArgsToSignature([])),
+              ),
+            );
+
+            // @ts-ignore: Assume that types from external packages are correct
+            path.node.typeParameters =
+              AST.builders.tsTypeParameterInstantiation([
+                AST.builders.tsTypeReference(
+                  AST.builders.identifier(
+                    `${data.entity.classifiedName}Signature`,
+                  ),
+                ),
+              ]);
+
+            break;
+          }
         }
-
-        const index = path.parentPath.parentPath.parentPath.name;
-
-        path.parentPath.parentPath.parentPath.parentPath.value.splice(
-          index,
-          0,
-          AST.builders.tsInterfaceDeclaration(
-            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            AST.builders.tsInterfaceBody(convertArgsToSignature([])),
-          ),
-        );
-
-        // @ts-ignore: Assume that types from external packages are correct
-        path.node.typeParameters = AST.builders.tsTypeParameterInstantiation([
-          AST.builders.tsTypeReference(
-            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-          ),
-        ]);
 
         return false;
       }
@@ -116,27 +150,59 @@ export function passSignatureToBaseComponent(
 
       // When the interface is missing
       if (!typeParameters) {
-        if (path.parentPath.node.type !== 'ExportDefaultDeclaration') {
-          return false;
+        switch (path.parentPath.node.type) {
+          case 'ExportDefaultDeclaration': {
+            const index = path.parentPath.name;
+
+            path.parentPath.parentPath.value.splice(
+              index,
+              0,
+              AST.builders.tsInterfaceDeclaration(
+                AST.builders.identifier(
+                  `${data.entity.classifiedName}Signature`,
+                ),
+                AST.builders.tsInterfaceBody(convertArgsToSignature([])),
+              ),
+            );
+
+            path.node.superTypeParameters =
+              AST.builders.tsTypeParameterInstantiation([
+                AST.builders.tsTypeReference(
+                  AST.builders.identifier(
+                    `${data.entity.classifiedName}Signature`,
+                  ),
+                ),
+              ]);
+
+            break;
+          }
+
+          case 'Program': {
+            const index = path.name;
+
+            path.parentPath.value.splice(
+              index,
+              0,
+              AST.builders.tsInterfaceDeclaration(
+                AST.builders.identifier(
+                  `${data.entity.classifiedName}Signature`,
+                ),
+                AST.builders.tsInterfaceBody(convertArgsToSignature([])),
+              ),
+            );
+
+            path.node.superTypeParameters =
+              AST.builders.tsTypeParameterInstantiation([
+                AST.builders.tsTypeReference(
+                  AST.builders.identifier(
+                    `${data.entity.classifiedName}Signature`,
+                  ),
+                ),
+              ]);
+
+            break;
+          }
         }
-
-        const index = path.parentPath.name;
-
-        path.parentPath.parentPath.value.splice(
-          index,
-          0,
-          AST.builders.tsInterfaceDeclaration(
-            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            AST.builders.tsInterfaceBody(convertArgsToSignature([])),
-          ),
-        );
-
-        path.node.superTypeParameters =
-          AST.builders.tsTypeParameterInstantiation([
-            AST.builders.tsTypeReference(
-              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            ),
-          ]);
 
         return false;
       }
@@ -199,27 +265,33 @@ export function passSignatureToBaseComponent(
       const typeParameters = path.node.superTypeParameters;
 
       if (!typeParameters) {
-        if (path.parentPath.node.type !== 'VariableDeclarator') {
-          return false;
+        switch (path.parentPath.node.type) {
+          case 'VariableDeclarator': {
+            const index = path.parentPath.parentPath.parentPath.name;
+
+            path.parentPath.parentPath.parentPath.parentPath.value.splice(
+              index,
+              0,
+              AST.builders.tsInterfaceDeclaration(
+                AST.builders.identifier(
+                  `${data.entity.classifiedName}Signature`,
+                ),
+                AST.builders.tsInterfaceBody(convertArgsToSignature([])),
+              ),
+            );
+
+            path.node.superTypeParameters =
+              AST.builders.tsTypeParameterInstantiation([
+                AST.builders.tsTypeReference(
+                  AST.builders.identifier(
+                    `${data.entity.classifiedName}Signature`,
+                  ),
+                ),
+              ]);
+
+            break;
+          }
         }
-
-        const index = path.parentPath.parentPath.parentPath.name;
-
-        path.parentPath.parentPath.parentPath.parentPath.value.splice(
-          index,
-          0,
-          AST.builders.tsInterfaceDeclaration(
-            AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            AST.builders.tsInterfaceBody(convertArgsToSignature([])),
-          ),
-        );
-
-        path.node.superTypeParameters =
-          AST.builders.tsTypeParameterInstantiation([
-            AST.builders.tsTypeReference(
-              AST.builders.identifier(`${data.entity.classifiedName}Signature`),
-            ),
-          ]);
 
         return false;
       }

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/navigation-menu.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const NavigationMenuComponent = templateOnlyComponent();
+interface NavigationMenuSignature {
+  Args: {};
+}
+
+const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();
 
 export default NavigationMenuComponent;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/card.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const ProductsProductCardComponent = templateOnlyComponent();
+interface ProductsProductCardSignature {
+  Args: {};
+}
+
+const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();
 
 export default ProductsProductCardComponent;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/image.ts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
-class ProductsProductImageComponent extends Component {
+interface ProductsProductImageSignature {
+  Args: {};
+}
+
+class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   isTestEnvironment = config.environment === 'test';
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget1Component = templateOnlyComponent();
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
 
 export default WidgetsWidget1Component;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4Component = templateOnlyComponent();
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 
 export default WidgetsWidget4Component;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4MemoComponent = templateOnlyComponent();
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
 
 export default WidgetsWidget4MemoComponent;
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4MemoActionsComponent = templateOnlyComponent();
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
 
 export default WidgetsWidget4MemoActionsComponent;
 

--- a/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/tracks/list.ts
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../data/album';
 
-type TracksListSignature = {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
-};
+}
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {

--- a/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/widgets/widget-4.ts
@@ -1,8 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-type WidgetsWidget4Signature = {
+interface WidgetsWidget4Signature {
   Args: {};
-};
+}
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 

--- a/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,8 +1,12 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const Body = class extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const Body = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default Body;

--- a/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,8 +1,12 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const Header = class FooComponent extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const Header = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default Header;

--- a/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/tracks/list.ts
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../data/album';
 
-type TracksListSignature = {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
-};
+}
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {

--- a/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/widgets/widget-4.ts
@@ -1,8 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-type WidgetsWidget4Signature = {
+interface WidgetsWidget4Signature {
   Args: {};
-};
+}
 
 const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 

--- a/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoBodyComponent = class extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-registries/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 import type { QueryResults } from 'ember-container-query';
 
-const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<{
-  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
-}> {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/navigation-menu.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const NavigationMenu = templateOnlyComponent();
+interface NavigationMenuSignature {
+  Args: {};
+}
+
+const NavigationMenu = templateOnlyComponent<NavigationMenuSignature>();
 
 export default NavigationMenu;

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/products/product/card.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const Component = templateOnlyComponent();
+interface ProductsProductCardSignature {
+  Args: {};
+}
+
+const Component = templateOnlyComponent<ProductsProductCardSignature>();
 
 export default Component;

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/products/product/image.ts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
-class ProductsProductImage extends Component {
+interface ProductsProductImageSignature {
+  Args: {};
+}
+
+class ProductsProductImage extends Component<ProductsProductImageSignature> {
   isTestEnvironment = config.environment === 'test';
 }
 

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-1.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget1Component = templateOnlyComponent();
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
 
 export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4Component = templateOnlyComponent();
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 
 export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4MemoComponent = templateOnlyComponent();
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
 
 export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,3 +1,7 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-export default templateOnlyComponent();
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {};
+}
+
+export default templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,5 +1,9 @@
 import Component from '@glimmer/component';
 
-const Body = class extends Component {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {};
+}
+
+const Body = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default Body;

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,5 +1,9 @@
 import Component from '@glimmer/component';
 
-const Header = class FooComponent extends Component {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {};
+}
+
+const Header = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default Header;

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/navigation-menu.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const NavigationMenuComponent = templateOnlyComponent();
+interface NavigationMenuSignature {
+  Args: {};
+}
+
+const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();
 
 export default NavigationMenuComponent;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/products/product/card.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const ProductsProductCardComponent = templateOnlyComponent();
+interface ProductsProductCardSignature {
+  Args: {};
+}
+
+const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();
 
 export default ProductsProductCardComponent;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/products/product/image.ts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
-class ProductsProductImageComponent extends Component {
+interface ProductsProductImageSignature {
+  Args: {};
+}
+
+class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   isTestEnvironment = config.environment === 'test';
 }
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-1.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget1Component = templateOnlyComponent();
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
 
 export default WidgetsWidget1Component;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4Component = templateOnlyComponent();
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 
 export default WidgetsWidget4Component;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4MemoComponent = templateOnlyComponent();
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
 
 export default WidgetsWidget4MemoComponent;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,6 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4MemoActionsComponent = templateOnlyComponent();
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
 
 export default WidgetsWidget4MemoActionsComponent;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 
-const WidgetsWidget4MemoBodyComponent = class extends Component {}
+interface WidgetsWidget4MemoBodySignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 
-const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component {}
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/navigation-menu.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const NavigationMenu = templateOnlyComponent();
+interface NavigationMenuSignature {
+  Args: {};
+}
+
+const NavigationMenu = templateOnlyComponent<NavigationMenuSignature>();
 
 export default NavigationMenu;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/card.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const Component = templateOnlyComponent();
+interface ProductsProductCardSignature {
+  Args: {};
+}
+
+const Component = templateOnlyComponent<ProductsProductCardSignature>();
 
 export default Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/products/product/image.ts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
-class ProductsProductImage extends Component {
+interface ProductsProductImageSignature {
+  Args: {};
+}
+
+class ProductsProductImage extends Component<ProductsProductImageSignature> {
   isTestEnvironment = config.environment === 'test';
 }
 

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-1.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget1Component = templateOnlyComponent();
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
 
 export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4Component = templateOnlyComponent();
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
 
 export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo.ts
@@ -1,5 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-const WidgetsWidget4MemoComponent = templateOnlyComponent();
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
 
 export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,3 +1,7 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-export default templateOnlyComponent();
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {};
+}
+
+export default templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();


### PR DESCRIPTION
## Description

In `tests/fixtures/steps/create-signatures` and `tests/fixtures/steps/create-registries`, we should no longer see these patterns in the `output` folder:

- `templateOnlyComponent(`
- `Component {`

That is, every component with a backing class should have a signature.
