### PR TITLE
Scaffolded context.signature

### DIFF
--- a/src/steps/analyze-project.ts
+++ b/src/steps/analyze-project.ts
@@ -1,14 +1,24 @@
 import type { Context, Options } from '../types/index.js';
 import {
   filterComponentEntities,
+  findArguments,
+  findBlocks,
   findComponentEntities,
+  findElement,
 } from './analyze-project/index.js';
 
 export function analyzeProject(options: Options): Context {
   let entities = findComponentEntities(options);
   entities = filterComponentEntities(entities, options);
 
+  const signature = {
+    Args: findArguments(options),
+    Blocks: findBlocks(options),
+    Element: findElement(options),
+  };
+
   return {
     entities,
+    signature,
   };
 }

--- a/src/steps/analyze-project/find-arguments.ts
+++ b/src/steps/analyze-project/find-arguments.ts
@@ -1,0 +1,8 @@
+import type { Options } from '../../types/index.js';
+
+// @ts-expect-error: Method to be implemented
+export function findArguments(options: Options): Set<string> | undefined {
+  // ...
+
+  return undefined;
+}

--- a/src/steps/analyze-project/find-blocks.ts
+++ b/src/steps/analyze-project/find-blocks.ts
@@ -1,0 +1,8 @@
+import type { Options } from '../../types/index.js';
+
+// @ts-expect-error: Method to be implemented
+export function findBlocks(options: Options): Set<string> | undefined {
+  // ...
+
+  return undefined;
+}

--- a/src/steps/analyze-project/find-element.ts
+++ b/src/steps/analyze-project/find-element.ts
@@ -1,0 +1,8 @@
+import type { Options } from '../../types/index.js';
+
+// @ts-expect-error: Method to be implemented
+export function findElement(options: Options): string | undefined {
+  // ...
+
+  return undefined;
+}

--- a/src/steps/analyze-project/index.ts
+++ b/src/steps/analyze-project/index.ts
@@ -1,2 +1,5 @@
 export * from './filter-component-entities.js';
+export * from './find-arguments.js';
+export * from './find-blocks.js';
 export * from './find-component-entities.js';
+export * from './find-element.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,11 @@ type CodemodOptions = {
 
 type Context = {
   entities: Entities;
+  signature: {
+    Args: Set<string> | undefined;
+    Blocks: Set<string> | undefined;
+    Element: string | undefined;
+  };
 };
 
 type Entities = Map<string, Set<string>>;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/card.ts
@@ -1,0 +1,10 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+import type { Product } from '../../../data/products';
+
+const Component = templateOnlyComponent<{
+  product: Product;
+  redirectTo?: string;
+}>();
+
+export default Component;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/products/product/image.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageArgs {
+  src: string;
+}
+
+class ProductsProductImage extends Component<ProductsProductImageArgs> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form.ts
@@ -1,0 +1,29 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormComponentArgs {
+  data?: Record<string, any>;
+  instructions?: string;
+  title?: string;
+}
+
+export default class UiFormComponent extends Component<UiFormComponentArgs> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/checkbox.ts
@@ -1,0 +1,51 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface CheckboxArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isInline?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+}
+
+export default class UiFormCheckboxComponent extends Component<CheckboxArgs> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/field.ts
@@ -1,0 +1,12 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldComponentArgs {
+  errorMessage?: string;
+  isInline?: boolean;
+  isWide?: boolean;
+}
+
+export default class extends Component<UiFormFieldComponentArgs> {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/input.ts
@@ -1,0 +1,48 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface InputComponentArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  placeholder?: string;
+  type?: string;
+}
+
+export default class UiFormInputComponent extends Component<InputComponentArgs> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/form/textarea.ts
@@ -1,0 +1,43 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface TextareaComponentArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  placeholder?: string;
+}
+
+export default class UiFormTextareaComponent extends Component<TextareaComponentArgs> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/ui/page.ts
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+interface UiPageComponentArgs {
+  title: string;
+}
+
+export default class UiPageComponent extends Component<UiPageComponentArgs> {}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent<{}>();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+export default class WidgetsWidget2Component extends Component<{}> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+export default class extends Component<{ summaries?: Summary[]; }> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2StackedChartArgs {
+  data: Data[];
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartArgs> {}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3.ts
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Args {}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Args> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Args) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,21 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface ResponsiveImageArgs {
+  images: Image[];
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<ResponsiveImageArgs> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args as ResponsiveImageArgs;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4.ts
@@ -1,0 +1,7 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type WidgetsWidget4Args = {};
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Args>();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,7 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface Args {}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<Args>();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,8 @@
+import templateOnlyComponent from '@ember/component/template-only';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoActionsArgs {
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}
+
+export default templateOnlyComponent<WidgetsWidget4MemoActionsArgs>();

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Body = class extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Body;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Header = class FooComponent extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Header;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/card.ts
@@ -1,0 +1,10 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+import type { Product } from '../../../data/products';
+
+const Component = templateOnlyComponent<{
+  product: Product;
+  redirectTo?: string;
+}>();
+
+export default Component;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/products/product/image.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageArgs {
+  src: string;
+}
+
+class ProductsProductImage extends Component<ProductsProductImageArgs> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form.ts
@@ -1,0 +1,29 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormComponentArgs {
+  data?: Record<string, any>;
+  instructions?: string;
+  title?: string;
+}
+
+export default class UiFormComponent extends Component<UiFormComponentArgs> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/checkbox.ts
@@ -1,0 +1,51 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface CheckboxArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isInline?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+}
+
+export default class UiFormCheckboxComponent extends Component<CheckboxArgs> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/field.ts
@@ -1,0 +1,12 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldComponentArgs {
+  errorMessage?: string;
+  isInline?: boolean;
+  isWide?: boolean;
+}
+
+export default class extends Component<UiFormFieldComponentArgs> {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/input.ts
@@ -1,0 +1,48 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface InputComponentArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  placeholder?: string;
+  type?: string;
+}
+
+export default class UiFormInputComponent extends Component<InputComponentArgs> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/form/textarea.ts
@@ -1,0 +1,43 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface TextareaComponentArgs {
+  changeset: Record<string, any>;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isWide?: boolean;
+  key: string;
+  label: string;
+  onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  placeholder?: string;
+}
+
+export default class UiFormTextareaComponent extends Component<TextareaComponentArgs> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/ui/page.ts
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+interface UiPageComponentArgs {
+  title: string;
+}
+
+export default class UiPageComponent extends Component<UiPageComponentArgs> {}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent<{}>();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+export default class WidgetsWidget2Component extends Component<{}> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+export default class extends Component<{ summaries?: Summary[]; }> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2StackedChartArgs {
+  data: Data[];
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartArgs> {}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3.ts
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Args {}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Args> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Args) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,21 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface ResponsiveImageArgs {
+  images: Image[];
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<ResponsiveImageArgs> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args as ResponsiveImageArgs;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4.ts
@@ -1,0 +1,7 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type WidgetsWidget4Args = {};
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Args>();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,7 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface Args {}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<Args>();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,8 @@
+import templateOnlyComponent from '@ember/component/template-only';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoActionsArgs {
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}
+
+export default templateOnlyComponent<WidgetsWidget4MemoActionsArgs>();

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Body = class extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Body;

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+const Header = class FooComponent extends Component<{
+  cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+}> {}
+
+export default Header;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/card.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const Component = templateOnlyComponent();
+
+export default Component;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/products/product/image.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+class ProductsProductImage extends Component {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class TracksComponent extends Component {}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form.ts
@@ -1,0 +1,23 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class UiFormComponent extends Component {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/checkbox.ts
@@ -1,0 +1,39 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormCheckboxComponent extends Component {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/field.ts
@@ -1,0 +1,6 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/input.ts
@@ -1,0 +1,35 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormInputComponent extends Component {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/form/textarea.ts
@@ -1,0 +1,31 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormTextareaComponent extends Component {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/ui/page.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class UiPageComponent extends Component {}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+export default class WidgetsWidget2Component extends Component {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+export default class extends Component {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class WidgetsWidget2StackedChartComponent extends Component {}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+export default class WidgetsWidget3Component extends Component {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4Component = templateOnlyComponent();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,3 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+export default templateOnlyComponent();

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Body = class extends Component {}
+
+export default Body;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Header = class FooComponent extends Component {}
+
+export default Header;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/card.hbs
@@ -1,0 +1,40 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/card.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const Component = templateOnlyComponent();
+
+export default Component;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/image.hbs
@@ -1,0 +1,12 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image"></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/products/product/image.ts
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+class ProductsProductImage extends Component {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImage;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class TracksComponent extends Component {}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form.hbs
@@ -1,0 +1,55 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form.ts
@@ -1,0 +1,23 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class UiFormComponent extends Component {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/checkbox.ts
@@ -1,0 +1,39 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormCheckboxComponent extends Component {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/field.ts
@@ -1,0 +1,6 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  inputId = guidFor(this);
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/input.ts
@@ -1,0 +1,35 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormInputComponent extends Component {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/form/textarea.ts
@@ -1,0 +1,31 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class UiFormTextareaComponent extends Component {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/page.hbs
@@ -1,0 +1,9 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div id="main-content" local-class="body" tabindex="-1">
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/ui/page.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class UiPageComponent extends Component {}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-1.hbs
@@ -1,0 +1,27 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-1.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget1Component = templateOnlyComponent();
+
+export default WidgetsWidget1Component;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+export default class WidgetsWidget2Component extends Component {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+export default class extends Component {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,3 @@
+import Component from '@glimmer/component';
+
+export default class WidgetsWidget2StackedChartComponent extends Component {}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+export default class WidgetsWidget3Component extends Component {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: {}) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4Component = templateOnlyComponent();
+
+export default WidgetsWidget4Component;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,5 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent();
+
+export default WidgetsWidget4MemoComponent;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,3 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+export default templateOnlyComponent();

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Body = class extends Component {}
+
+export default Body;

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+const Header = class FooComponent extends Component {}
+
+export default Header;

--- a/tests/helpers/shared-test-setups/classic-components.ts
+++ b/tests/helpers/shared-test-setups/classic-components.ts
@@ -12,6 +12,11 @@ const codemodOptions: CodemodOptions = {
 
 const context: Context = {
   entities: new Map(),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/ember-container-query-addon.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-addon.ts
@@ -43,6 +43,11 @@ const context: Context = {
     ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ['widgets/widget-5', new Set(['.d.ts', '.hbs'])],
   ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/ember-container-query-glint.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-glint.ts
@@ -43,6 +43,11 @@ const context: Context = {
     ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ['widgets/widget-5', new Set(['.hbs', '.ts'])],
   ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/ember-container-query-nested.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-nested.ts
@@ -43,6 +43,11 @@ const context: Context = {
     ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ['widgets/widget-5', new Set(['.d.ts', '.hbs'])],
   ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -43,6 +43,11 @@ const context: Context = {
     ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ['widgets/widget-5', new Set(['.hbs'])],
   ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -43,6 +43,11 @@ const context: Context = {
     ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ['widgets/widget-5', new Set(['.d.ts', '.hbs'])],
   ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
 };
 
 const options: Options = {

--- a/tests/helpers/shared-test-setups/has-backing-class.ts
+++ b/tests/helpers/shared-test-setups/has-backing-class.ts
@@ -1,0 +1,53 @@
+import type {
+  CodemodOptions,
+  Context,
+  Options,
+} from '../../../src/types/index.js';
+
+const codemodOptions: CodemodOptions = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-backing-class',
+  src: 'app/components',
+};
+
+const context: Context = {
+  entities: new Map([
+    ['navigation-menu', new Set(['.hbs', '.ts'])],
+    ['products/product/card', new Set(['.hbs', '.ts'])],
+    ['products/product/image', new Set(['.hbs', '.ts'])],
+    ['tracks/list', new Set(['.hbs', '.ts'])],
+    ['ui/form', new Set(['.hbs', '.ts'])],
+    ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
+    ['ui/form/field', new Set(['.hbs', '.ts'])],
+    ['ui/form/input', new Set(['.hbs', '.ts'])],
+    ['ui/form/textarea', new Set(['.hbs', '.ts'])],
+    ['ui/page', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-1', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-2', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-3', new Set(['.hbs', '.ts'])],
+    [
+      'widgets/widget-3/tour-schedule/responsive-image',
+      new Set(['.hbs', '.ts']),
+    ],
+    ['widgets/widget-4', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
+  ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
+};
+
+const options: Options = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-backing-class',
+  src: 'app/components',
+};
+
+export { codemodOptions, context, options };

--- a/tests/helpers/shared-test-setups/has-declaration-file.ts
+++ b/tests/helpers/shared-test-setups/has-declaration-file.ts
@@ -1,0 +1,31 @@
+import type {
+  CodemodOptions,
+  Context,
+  Options,
+} from '../../../src/types/index.js';
+
+const codemodOptions: CodemodOptions = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-declaration-file',
+  src: 'app/components',
+};
+
+const context: Context = {
+  entities: new Map([
+    ['tracks', new Set(['.d.ts', '.hbs'])],
+    ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
+  ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
+};
+
+const options: Options = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-declaration-file',
+  src: 'app/components',
+};
+
+export { codemodOptions, context, options };

--- a/tests/helpers/shared-test-setups/has-hbs-file-only.ts
+++ b/tests/helpers/shared-test-setups/has-hbs-file-only.ts
@@ -1,0 +1,31 @@
+import type {
+  CodemodOptions,
+  Context,
+  Options,
+} from '../../../src/types/index.js';
+
+const codemodOptions: CodemodOptions = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-hbs-file-only',
+  src: 'app/components',
+};
+
+const context: Context = {
+  entities: new Map([
+    ['ui/form/information', new Set(['.hbs'])],
+    ['widgets/widget-5', new Set(['.hbs'])],
+  ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
+};
+
+const options: Options = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-hbs-file-only',
+  src: 'app/components',
+};
+
+export { codemodOptions, context, options };

--- a/tests/helpers/shared-test-setups/has-no-args.ts
+++ b/tests/helpers/shared-test-setups/has-no-args.ts
@@ -1,0 +1,54 @@
+import type {
+  CodemodOptions,
+  Context,
+  Options,
+} from '../../../src/types/index.js';
+
+const codemodOptions: CodemodOptions = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-no-args',
+  src: 'app/components',
+};
+
+const context: Context = {
+  entities: new Map([
+    ['navigation-menu', new Set(['.hbs', '.ts'])],
+    ['products/product/card', new Set(['.hbs', '.ts'])],
+    ['products/product/image', new Set(['.hbs', '.ts'])],
+    ['tracks', new Set(['.hbs', '.ts'])],
+    ['tracks/list', new Set(['.hbs', '.ts'])],
+    ['ui/form', new Set(['.hbs', '.ts'])],
+    ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
+    ['ui/form/field', new Set(['.hbs', '.ts'])],
+    ['ui/form/input', new Set(['.hbs', '.ts'])],
+    ['ui/form/textarea', new Set(['.hbs', '.ts'])],
+    ['ui/page', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-1', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-2', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-3', new Set(['.hbs', '.ts'])],
+    [
+      'widgets/widget-3/tour-schedule/responsive-image',
+      new Set(['.hbs', '.ts']),
+    ],
+    ['widgets/widget-4', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
+    ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
+  ]),
+  signature: {
+    Args: undefined,
+    Blocks: undefined,
+    Element: undefined,
+  },
+};
+
+const options: Options = {
+  componentStructure: 'flat',
+  projectRoot: 'tmp/has-no-args',
+  src: 'app/components',
+};
+
+export { codemodOptions, context, options };

--- a/tests/steps/create-registries/has-backing-class.test.ts
+++ b/tests/steps/create-registries/has-backing-class.test.ts
@@ -8,8 +8,9 @@ import {
 import { createRegistries } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-backing-class.js';
 
 test('steps | create-registries > has-backing-class', function () {
   const inputProject = convertFixtureToJson(
@@ -19,40 +20,6 @@ test('steps | create-registries > has-backing-class', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-registries/has-backing-class/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['navigation-menu', new Set(['.hbs', '.ts'])],
-      ['products/product/card', new Set(['.hbs', '.ts'])],
-      ['products/product/image', new Set(['.hbs', '.ts'])],
-      ['tracks/list', new Set(['.hbs', '.ts'])],
-      ['ui/form', new Set(['.hbs', '.ts'])],
-      ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
-      ['ui/form/field', new Set(['.hbs', '.ts'])],
-      ['ui/form/input', new Set(['.hbs', '.ts'])],
-      ['ui/form/textarea', new Set(['.hbs', '.ts'])],
-      ['ui/page', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-1', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-3', new Set(['.hbs', '.ts'])],
-      [
-        'widgets/widget-3/tour-schedule/responsive-image',
-        new Set(['.hbs', '.ts']),
-      ],
-      ['widgets/widget-4', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-registries/has-backing-class.test.ts
+++ b/tests/steps/create-registries/has-backing-class.test.ts
@@ -47,6 +47,11 @@ test('steps | create-registries > has-backing-class', function () {
       ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
       ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-registries/has-declaration-file.test.ts
+++ b/tests/steps/create-registries/has-declaration-file.test.ts
@@ -25,6 +25,11 @@ test('steps | create-registries > has-declaration-file', function () {
       ['tracks', new Set(['.d.ts', '.hbs'])],
       ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-registries/has-declaration-file.test.ts
+++ b/tests/steps/create-registries/has-declaration-file.test.ts
@@ -8,8 +8,9 @@ import {
 import { createRegistries } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-declaration-file.js';
 
 test('steps | create-registries > has-declaration-file', function () {
   const inputProject = convertFixtureToJson(
@@ -19,18 +20,6 @@ test('steps | create-registries > has-declaration-file', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-registries/has-declaration-file/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['tracks', new Set(['.d.ts', '.hbs'])],
-      ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-registries/has-hbs-file-only.test.ts
+++ b/tests/steps/create-registries/has-hbs-file-only.test.ts
@@ -25,6 +25,11 @@ test('steps | create-registries > has-hbs-file-only', function () {
       ['ui/form/information', new Set(['.hbs'])],
       ['widgets/widget-5', new Set(['.hbs'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-registries/has-hbs-file-only.test.ts
+++ b/tests/steps/create-registries/has-hbs-file-only.test.ts
@@ -8,8 +8,9 @@ import {
 import { createRegistries } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-hbs-file-only.js';
 
 test('steps | create-registries > has-hbs-file-only', function () {
   const inputProject = convertFixtureToJson(
@@ -19,18 +20,6 @@ test('steps | create-registries > has-hbs-file-only', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-registries/has-hbs-file-only/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['ui/form/information', new Set(['.hbs'])],
-      ['widgets/widget-5', new Set(['.hbs'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-registries/has-no-args.test.ts
+++ b/tests/steps/create-registries/has-no-args.test.ts
@@ -8,8 +8,9 @@ import {
 import { createRegistries } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query-no-args.js';
+} from '../../helpers/shared-test-setups/has-no-args.js';
 
 test('steps | create-registries > has-no-args', function () {
   const inputProject = convertFixtureToJson(
@@ -19,41 +20,6 @@ test('steps | create-registries > has-no-args', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-registries/has-no-args/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['navigation-menu', new Set(['.hbs', '.ts'])],
-      ['products/product/card', new Set(['.hbs', '.ts'])],
-      ['products/product/image', new Set(['.hbs', '.ts'])],
-      ['tracks', new Set(['.hbs', '.ts'])],
-      ['tracks/list', new Set(['.hbs', '.ts'])],
-      ['ui/form', new Set(['.hbs', '.ts'])],
-      ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
-      ['ui/form/field', new Set(['.hbs', '.ts'])],
-      ['ui/form/input', new Set(['.hbs', '.ts'])],
-      ['ui/form/textarea', new Set(['.hbs', '.ts'])],
-      ['ui/page', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-1', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-3', new Set(['.hbs', '.ts'])],
-      [
-        'widgets/widget-3/tour-schedule/responsive-image',
-        new Set(['.hbs', '.ts']),
-      ],
-      ['widgets/widget-4', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-registries/has-no-args.test.ts
+++ b/tests/steps/create-registries/has-no-args.test.ts
@@ -48,6 +48,11 @@ test('steps | create-registries > has-no-args', function () {
       ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
       ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-signatures/has-backing-class.test.ts
+++ b/tests/steps/create-signatures/has-backing-class.test.ts
@@ -47,6 +47,11 @@ test('steps | create-signatures > has-backing-class', function () {
       ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
       ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-signatures/has-backing-class.test.ts
+++ b/tests/steps/create-signatures/has-backing-class.test.ts
@@ -8,8 +8,9 @@ import {
 import { createSignatures } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-backing-class.js';
 
 test('steps | create-signatures > has-backing-class', function () {
   const inputProject = convertFixtureToJson(
@@ -19,40 +20,6 @@ test('steps | create-signatures > has-backing-class', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-signatures/has-backing-class/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['navigation-menu', new Set(['.hbs', '.ts'])],
-      ['products/product/card', new Set(['.hbs', '.ts'])],
-      ['products/product/image', new Set(['.hbs', '.ts'])],
-      ['tracks/list', new Set(['.hbs', '.ts'])],
-      ['ui/form', new Set(['.hbs', '.ts'])],
-      ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
-      ['ui/form/field', new Set(['.hbs', '.ts'])],
-      ['ui/form/input', new Set(['.hbs', '.ts'])],
-      ['ui/form/textarea', new Set(['.hbs', '.ts'])],
-      ['ui/page', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-1', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-3', new Set(['.hbs', '.ts'])],
-      [
-        'widgets/widget-3/tour-schedule/responsive-image',
-        new Set(['.hbs', '.ts']),
-      ],
-      ['widgets/widget-4', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-signatures/has-declaration-file.test.ts
+++ b/tests/steps/create-signatures/has-declaration-file.test.ts
@@ -8,8 +8,9 @@ import {
 import { createSignatures } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-declaration-file.js';
 
 test('steps | create-signatures > has-declaration-file', function () {
   const inputProject = convertFixtureToJson(
@@ -19,18 +20,6 @@ test('steps | create-signatures > has-declaration-file', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-signatures/has-declaration-file/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['tracks', new Set(['.d.ts', '.hbs'])],
-      ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-signatures/has-declaration-file.test.ts
+++ b/tests/steps/create-signatures/has-declaration-file.test.ts
@@ -25,6 +25,11 @@ test('steps | create-signatures > has-declaration-file', function () {
       ['tracks', new Set(['.d.ts', '.hbs'])],
       ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-signatures/has-hbs-file-only.test.ts
+++ b/tests/steps/create-signatures/has-hbs-file-only.test.ts
@@ -25,6 +25,11 @@ test('steps | create-signatures > has-hbs-file-only', function () {
       ['ui/form/information', new Set(['.hbs'])],
       ['widgets/widget-5', new Set(['.hbs'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-signatures/has-hbs-file-only.test.ts
+++ b/tests/steps/create-signatures/has-hbs-file-only.test.ts
@@ -8,8 +8,9 @@ import {
 import { createSignatures } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-hbs-file-only.js';
 
 test('steps | create-signatures > has-hbs-file-only', function () {
   const inputProject = convertFixtureToJson(
@@ -19,18 +20,6 @@ test('steps | create-signatures > has-hbs-file-only', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-signatures/has-hbs-file-only/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['ui/form/information', new Set(['.hbs'])],
-      ['widgets/widget-5', new Set(['.hbs'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-signatures/has-no-args.test.ts
+++ b/tests/steps/create-signatures/has-no-args.test.ts
@@ -48,6 +48,11 @@ test('steps | create-signatures > has-no-args', function () {
       ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
       ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-signatures/has-no-args.test.ts
+++ b/tests/steps/create-signatures/has-no-args.test.ts
@@ -8,8 +8,9 @@ import {
 import { createSignatures } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query-no-args.js';
+} from '../../helpers/shared-test-setups/has-no-args.js';
 
 test('steps | create-signatures > has-no-args', function () {
   const inputProject = convertFixtureToJson(
@@ -19,41 +20,6 @@ test('steps | create-signatures > has-no-args', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-signatures/has-no-args/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['navigation-menu', new Set(['.hbs', '.ts'])],
-      ['products/product/card', new Set(['.hbs', '.ts'])],
-      ['products/product/image', new Set(['.hbs', '.ts'])],
-      ['tracks', new Set(['.hbs', '.ts'])],
-      ['tracks/list', new Set(['.hbs', '.ts'])],
-      ['ui/form', new Set(['.hbs', '.ts'])],
-      ['ui/form/checkbox', new Set(['.hbs', '.ts'])],
-      ['ui/form/field', new Set(['.hbs', '.ts'])],
-      ['ui/form/input', new Set(['.hbs', '.ts'])],
-      ['ui/form/textarea', new Set(['.hbs', '.ts'])],
-      ['ui/page', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-1', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/captions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-2/stacked-chart', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-3', new Set(['.hbs', '.ts'])],
-      [
-        'widgets/widget-3/tour-schedule/responsive-image',
-        new Set(['.hbs', '.ts']),
-      ],
-      ['widgets/widget-4', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/actions', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/body', new Set(['.hbs', '.ts'])],
-      ['widgets/widget-4/memo/header', new Set(['.hbs', '.ts'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-template-only-components/has-backing-class.test.ts
+++ b/tests/steps/create-template-only-components/has-backing-class.test.ts
@@ -8,6 +8,7 @@ import {
 import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
 } from '../../helpers/shared-test-setups/has-backing-class.js';
 
@@ -19,18 +20,6 @@ test('steps | create-template-only-components > has-backing-class', function () 
   const outputProject = convertFixtureToJson(
     'steps/create-template-only-components/has-backing-class/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['navigation-menu', new Set(['.hbs', '.ts'])],
-      ['tracks/list', new Set(['.hbs', '.ts'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-template-only-components/has-backing-class.test.ts
+++ b/tests/steps/create-template-only-components/has-backing-class.test.ts
@@ -25,6 +25,11 @@ test('steps | create-template-only-components > has-backing-class', function () 
       ['navigation-menu', new Set(['.hbs', '.ts'])],
       ['tracks/list', new Set(['.hbs', '.ts'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-template-only-components/has-backing-class.test.ts
+++ b/tests/steps/create-template-only-components/has-backing-class.test.ts
@@ -9,7 +9,7 @@ import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
 import {
   codemodOptions,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-backing-class.js';
 
 test('steps | create-template-only-components > has-backing-class', function () {
   const inputProject = convertFixtureToJson(

--- a/tests/steps/create-template-only-components/has-declaration-file.test.ts
+++ b/tests/steps/create-template-only-components/has-declaration-file.test.ts
@@ -8,8 +8,9 @@ import {
 import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-declaration-file.js';
 
 test('steps | create-template-only-components > has-declaration-file', function () {
   const inputProject = convertFixtureToJson(
@@ -19,18 +20,6 @@ test('steps | create-template-only-components > has-declaration-file', function 
   const outputProject = convertFixtureToJson(
     'steps/create-template-only-components/has-declaration-file/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['tracks', new Set(['.d.ts', '.hbs'])],
-      ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-template-only-components/has-declaration-file.test.ts
+++ b/tests/steps/create-template-only-components/has-declaration-file.test.ts
@@ -25,6 +25,11 @@ test('steps | create-template-only-components > has-declaration-file', function 
       ['tracks', new Set(['.d.ts', '.hbs'])],
       ['widgets/widget-3/tour-schedule', new Set(['.d.ts', '.hbs'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-template-only-components/has-hbs-file-only.test.ts
+++ b/tests/steps/create-template-only-components/has-hbs-file-only.test.ts
@@ -8,8 +8,9 @@ import {
 import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query.js';
+} from '../../helpers/shared-test-setups/has-hbs-file-only.js';
 
 test('steps | create-template-only-components > has-hbs-file-only', function () {
   const inputProject = convertFixtureToJson(
@@ -19,18 +20,6 @@ test('steps | create-template-only-components > has-hbs-file-only', function () 
   const outputProject = convertFixtureToJson(
     'steps/create-template-only-components/has-hbs-file-only/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['ui/form/information', new Set(['.hbs'])],
-      ['widgets/widget-5', new Set(['.hbs'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-template-only-components/has-hbs-file-only.test.ts
+++ b/tests/steps/create-template-only-components/has-hbs-file-only.test.ts
@@ -25,6 +25,11 @@ test('steps | create-template-only-components > has-hbs-file-only', function () 
       ['ui/form/information', new Set(['.hbs'])],
       ['widgets/widget-5', new Set(['.hbs'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);

--- a/tests/steps/create-template-only-components/has-no-args.test.ts
+++ b/tests/steps/create-template-only-components/has-no-args.test.ts
@@ -8,6 +8,7 @@ import {
 import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
 import {
   codemodOptions,
+  context,
   options,
 } from '../../helpers/shared-test-setups/has-no-args.js';
 
@@ -19,18 +20,6 @@ test('steps | create-template-only-components > has-no-args', function () {
   const outputProject = convertFixtureToJson(
     'steps/create-template-only-components/has-no-args/output',
   );
-
-  const context = {
-    entities: new Map([
-      ['navigation-menu', new Set(['.hbs', '.ts'])],
-      ['tracks/list', new Set(['.hbs', '.ts'])],
-    ]),
-    signature: {
-      Args: undefined,
-      Blocks: undefined,
-      Element: undefined,
-    },
-  };
 
   loadFixture(inputProject, codemodOptions);
 

--- a/tests/steps/create-template-only-components/has-no-args.test.ts
+++ b/tests/steps/create-template-only-components/has-no-args.test.ts
@@ -9,7 +9,7 @@ import { createTemplateOnlyComponents } from '../../../src/steps/index.js';
 import {
   codemodOptions,
   options,
-} from '../../helpers/shared-test-setups/ember-container-query-no-args.js';
+} from '../../helpers/shared-test-setups/has-no-args.js';
 
 test('steps | create-template-only-components > has-no-args', function () {
   const inputProject = convertFixtureToJson(

--- a/tests/steps/create-template-only-components/has-no-args.test.ts
+++ b/tests/steps/create-template-only-components/has-no-args.test.ts
@@ -25,6 +25,11 @@ test('steps | create-template-only-components > has-no-args', function () {
       ['navigation-menu', new Set(['.hbs', '.ts'])],
       ['tracks/list', new Set(['.hbs', '.ts'])],
     ]),
+    signature: {
+      Args: undefined,
+      Blocks: undefined,
+      Element: undefined,
+    },
   };
 
   loadFixture(inputProject, codemodOptions);


### PR DESCRIPTION
## Description

As of `v0.1.5`, `ember-codemod-args-to-signature` can scaffold the `Signature` and in a consistent manner (i.e. the `interface` keyword is used, the signature appears before the component declaration). We'd like to now fill out the signature for the end-developer as much as possible.

To help split the task, I scaffolded `context.signature` in the `analyze-project` step.
