### PR TITLE
Fixed a formatting bug

### DIFF
--- a/src/steps/create-registries/has-registry.ts
+++ b/src/steps/create-registries/has-registry.ts
@@ -7,7 +7,10 @@ export function hasRegistry(file: string): boolean {
 
   traverse(file, {
     visitTSModuleDeclaration(path) {
-      // @ts-ignore: Assume that types from external packages are correct
+      if (path.node.id.type !== 'StringLiteral') {
+        return false;
+      }
+
       const moduleName = path.node.id.value;
 
       if (moduleName === '@glint/environment-ember-loose/registry') {

--- a/src/steps/create-registries/pass-component-name-to-base-component.ts
+++ b/src/steps/create-registries/pass-component-name-to-base-component.ts
@@ -52,19 +52,17 @@ export function passComponentNameToBaseComponent(
         return false;
       }
 
-      // @ts-ignore: Assume that types from external packages are correct
-      switch (declaration.init.type) {
+      switch (declaration.init!.type) {
         case 'CallExpression': {
           if (
             declaration.init.callee.type !== 'Identifier' ||
-            declaration.init.callee.name !== baseComponentName
+            declaration.init.callee.name !== baseComponentName ||
+            declaration.id.type !== 'Identifier'
           ) {
             return false;
           }
 
-          // @ts-ignore: Assume that types from external packages are correct
           componentName = declaration.id.name;
-          // @ts-ignore: Assume that types from external packages are correct
           declaration.id.name = `${data.entity.classifiedName}Component`;
 
           return false;
@@ -74,14 +72,13 @@ export function passComponentNameToBaseComponent(
           if (
             !declaration.init.superClass ||
             declaration.init.superClass.type !== 'Identifier' ||
-            declaration.init.superClass.name !== baseComponentName
+            declaration.init.superClass.name !== baseComponentName ||
+            declaration.id.type !== 'Identifier'
           ) {
             return false;
           }
 
-          // @ts-ignore: Assume that types from external packages are correct
           componentName = declaration.id.name;
-          // @ts-ignore: Assume that types from external packages are correct
           declaration.id.name = `${data.entity.classifiedName}Component`;
 
           return false;

--- a/src/steps/create-registries/rename-component.ts
+++ b/src/steps/create-registries/rename-component.ts
@@ -16,17 +16,14 @@ export function renameComponent(file: string, data: Data): string {
     return file;
   }
 
-  // eslint-disable-next-line prefer-const
-  let { componentName, newFile } = passComponentNameToBaseComponent(file, {
+  const { componentName, newFile } = passComponentNameToBaseComponent(file, {
     baseComponentName,
     data,
   });
 
-  ({ newFile } = updateReferences(newFile, {
+  return updateReferences(newFile, {
     baseComponentName,
     componentName,
     data,
-  }));
-
-  return newFile;
+  });
 }

--- a/src/steps/create-registries/update-references.ts
+++ b/src/steps/create-registries/update-references.ts
@@ -10,12 +10,7 @@ type Options = {
   };
 };
 
-export function updateReferences(
-  file: string,
-  options: Options,
-): {
-  newFile: string;
-} {
+export function updateReferences(file: string, options: Options): string {
   const traverse = AST.traverse(true);
 
   const { baseComponentName, componentName, data } = options;
@@ -63,7 +58,5 @@ export function updateReferences(
     },
   });
 
-  return {
-    newFile: AST.print(ast),
-  };
+  return AST.print(ast);
 }

--- a/src/steps/create-signatures/builders.ts
+++ b/src/steps/create-signatures/builders.ts
@@ -1,7 +1,7 @@
 import { AST } from '@codemod-utils/ast-javascript';
 
-function builderConvertArgsToSignature(nodes: unknown[]) {
-  return AST.builders.tsInterfaceBody([
+export function builderConvertArgsToSignature(nodes: unknown[] = []) {
+  return [
     AST.builders.tsPropertySignature(
       AST.builders.identifier('Args'),
       // @ts-ignore: Assume that types from external packages are correct
@@ -27,13 +27,14 @@ function builderConvertArgsToSignature(nodes: unknown[]) {
     //   AST.builders.tsTypeAnnotation(AST.builders.tsNullKeyword()),
     //   false,
     // ),
-  ]);
+  ];
 }
 
-export function builderAddSignature(identifier: string, nodes: unknown[] = []) {
+export function builderCreateSignature(identifier: string, members: unknown[]) {
   return AST.builders.tsInterfaceDeclaration(
     AST.builders.identifier(identifier),
-    builderConvertArgsToSignature(nodes),
+    // @ts-ignore: Assume that types from external packages are correct
+    AST.builders.tsInterfaceBody(members),
   );
 }
 

--- a/src/steps/create-signatures/create-signature.ts
+++ b/src/steps/create-signatures/create-signature.ts
@@ -23,18 +23,16 @@ export function createSignature(file: string, data: Data): string {
     data,
   });
 
-  ({ newFile } = updateConstructor(newFile, {
+  newFile = updateConstructor(newFile, {
     data,
-  }));
+  });
 
   if (interfaceName === undefined) {
     return newFile;
   }
 
-  ({ newFile } = updateReferences(newFile, {
+  return updateReferences(newFile, {
     data,
     interfaceName,
-  }));
-
-  return newFile;
+  });
 }

--- a/src/steps/create-signatures/pass-signature-to-base-component.ts
+++ b/src/steps/create-signatures/pass-signature-to-base-component.ts
@@ -215,11 +215,13 @@ export function passSignatureToBaseComponent(
 
         // When the interface is defined "outside"
         case 'TSTypeReference': {
+          if (typeParameter.typeName.type !== 'Identifier') {
+            break;
+          }
+
           const identifier = `${data.entity.classifiedName}Signature`;
 
-          // @ts-ignore: Assume that types from external packages are correct
           interfaceName = typeParameter.typeName.name;
-          // @ts-ignore: Assume that types from external packages are correct
           typeParameter.typeName.name = identifier;
 
           return false;
@@ -288,11 +290,13 @@ export function passSignatureToBaseComponent(
 
         // When the interface is defined "outside"
         case 'TSTypeReference': {
+          if (typeParameter.typeName.type !== 'Identifier') {
+            break;
+          }
+
           const identifier = `${data.entity.classifiedName}Signature`;
 
-          // @ts-ignore: Assume that types from external packages are correct
           interfaceName = typeParameter.typeName.name;
-          // @ts-ignore: Assume that types from external packages are correct
           typeParameter.typeName.name = identifier;
 
           return false;

--- a/src/steps/create-signatures/pass-signature-to-base-component.ts
+++ b/src/steps/create-signatures/pass-signature-to-base-component.ts
@@ -1,7 +1,11 @@
 import { AST } from '@codemod-utils/ast-javascript';
 
 import type { TransformedEntityName } from '../../utils/components.js';
-import { builderAddSignature, builderPassSignature } from './builders.js';
+import {
+  builderConvertArgsToSignature,
+  builderCreateSignature,
+  builderPassSignature,
+} from './builders.js';
 import { isSignature } from './is-signature.js';
 
 type Options = {
@@ -37,6 +41,8 @@ export function passSignatureToBaseComponent(
 
       // When the interface is missing
       if (!typeParameters) {
+        const members = builderConvertArgsToSignature();
+
         switch (path.parentPath.node.type) {
           case 'ExportDefaultDeclaration': {
             const identifier = `${data.entity.classifiedName}Signature`;
@@ -45,7 +51,7 @@ export function passSignatureToBaseComponent(
             path.parentPath.parentPath.value.splice(
               index,
               0,
-              builderAddSignature(identifier),
+              builderCreateSignature(identifier, members),
             );
 
             // @ts-ignore: Assume that types from external packages are correct
@@ -61,7 +67,7 @@ export function passSignatureToBaseComponent(
             path.parentPath.parentPath.parentPath.parentPath.value.splice(
               index,
               0,
-              builderAddSignature(identifier),
+              builderCreateSignature(identifier, members),
             );
 
             // @ts-ignore: Assume that types from external packages are correct
@@ -79,29 +85,53 @@ export function passSignatureToBaseComponent(
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
-          if (isSignature(typeParameter.members)) {
-            break;
+          const members = isSignature(typeParameter.members)
+            ? typeParameter.members
+            : builderConvertArgsToSignature(typeParameter.members);
+
+          switch (path.parentPath.node.type) {
+            case 'ExportDefaultDeclaration': {
+              const identifier = `${data.entity.classifiedName}Signature`;
+              const index = path.parentPath.name;
+
+              path.parentPath.parentPath.value.splice(
+                index,
+                0,
+                builderCreateSignature(identifier, members),
+              );
+
+              // @ts-ignore: Assume that types from external packages are correct
+              path.node.typeParameters = builderPassSignature(identifier);
+
+              break;
+            }
+
+            case 'VariableDeclarator': {
+              const identifier = `${data.entity.classifiedName}Signature`;
+              const index = path.parentPath.parentPath.parentPath.name;
+
+              path.parentPath.parentPath.parentPath.parentPath.value.splice(
+                index,
+                0,
+                builderCreateSignature(identifier, members),
+              );
+
+              // @ts-ignore: Assume that types from external packages are correct
+              path.node.typeParameters = builderPassSignature(identifier);
+
+              break;
+            }
           }
-
-          const identifier = `${data.entity.classifiedName}Signature`;
-          const index = path.parentPath.parentPath.parentPath.name;
-
-          path.parentPath.parentPath.parentPath.parentPath.value.splice(
-            index,
-            0,
-            builderAddSignature(identifier, typeParameter.members),
-          );
-
-          // @ts-ignore: Assume that types from external packages are correct
-          path.node.typeParameters = builderPassSignature(identifier);
 
           return false;
         }
 
         // When the interface is defined "outside"
         case 'TSTypeReference': {
+          const identifier = `${data.entity.classifiedName}Signature`;
+
           interfaceName = typeParameter.typeName.name;
-          typeParameter.typeName.name = `${data.entity.classifiedName}Signature`;
+          typeParameter.typeName.name = identifier;
 
           return false;
         }
@@ -123,6 +153,8 @@ export function passSignatureToBaseComponent(
 
       // When the interface is missing
       if (!typeParameters) {
+        const members = builderConvertArgsToSignature();
+
         switch (path.parentPath.node.type) {
           case 'ExportDefaultDeclaration': {
             const identifier = `${data.entity.classifiedName}Signature`;
@@ -131,7 +163,7 @@ export function passSignatureToBaseComponent(
             path.parentPath.parentPath.value.splice(
               index,
               0,
-              builderAddSignature(identifier),
+              builderCreateSignature(identifier, members),
             );
 
             path.node.superTypeParameters = builderPassSignature(identifier);
@@ -146,7 +178,7 @@ export function passSignatureToBaseComponent(
             path.parentPath.value.splice(
               index,
               0,
-              builderAddSignature(identifier),
+              builderCreateSignature(identifier, members),
             );
 
             path.node.superTypeParameters = builderPassSignature(identifier);
@@ -163,9 +195,9 @@ export function passSignatureToBaseComponent(
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
-          if (isSignature(typeParameter.members)) {
-            break;
-          }
+          const members = isSignature(typeParameter.members)
+            ? typeParameter.members
+            : builderConvertArgsToSignature(typeParameter.members);
 
           const identifier = `${data.entity.classifiedName}Signature`;
           const index = path.parentPath.name;
@@ -173,7 +205,7 @@ export function passSignatureToBaseComponent(
           path.parentPath.parentPath.value.splice(
             index,
             0,
-            builderAddSignature(identifier, typeParameter.members),
+            builderCreateSignature(identifier, members),
           );
 
           path.node.superTypeParameters = builderPassSignature(identifier);
@@ -183,10 +215,12 @@ export function passSignatureToBaseComponent(
 
         // When the interface is defined "outside"
         case 'TSTypeReference': {
+          const identifier = `${data.entity.classifiedName}Signature`;
+
           // @ts-ignore: Assume that types from external packages are correct
           interfaceName = typeParameter.typeName.name;
           // @ts-ignore: Assume that types from external packages are correct
-          typeParameter.typeName.name = `${data.entity.classifiedName}Signature`;
+          typeParameter.typeName.name = identifier;
 
           return false;
         }
@@ -207,6 +241,8 @@ export function passSignatureToBaseComponent(
       const typeParameters = path.node.superTypeParameters;
 
       if (!typeParameters) {
+        const members = builderConvertArgsToSignature();
+
         switch (path.parentPath.node.type) {
           case 'VariableDeclarator': {
             const identifier = `${data.entity.classifiedName}Signature`;
@@ -215,7 +251,7 @@ export function passSignatureToBaseComponent(
             path.parentPath.parentPath.parentPath.parentPath.value.splice(
               index,
               0,
-              builderAddSignature(identifier),
+              builderCreateSignature(identifier, members),
             );
 
             path.node.superTypeParameters = builderPassSignature(identifier);
@@ -232,9 +268,9 @@ export function passSignatureToBaseComponent(
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
-          if (isSignature(typeParameter.members)) {
-            break;
-          }
+          const members = isSignature(typeParameter.members)
+            ? typeParameter.members
+            : builderConvertArgsToSignature(typeParameter.members);
 
           const identifier = `${data.entity.classifiedName}Signature`;
           const index = path.parentPath.parentPath.parentPath.name;
@@ -242,7 +278,7 @@ export function passSignatureToBaseComponent(
           path.parentPath.parentPath.parentPath.parentPath.value.splice(
             index,
             0,
-            builderAddSignature(identifier, typeParameter.members),
+            builderCreateSignature(identifier, members),
           );
 
           path.node.superTypeParameters = builderPassSignature(identifier);
@@ -252,10 +288,12 @@ export function passSignatureToBaseComponent(
 
         // When the interface is defined "outside"
         case 'TSTypeReference': {
+          const identifier = `${data.entity.classifiedName}Signature`;
+
           // @ts-ignore: Assume that types from external packages are correct
           interfaceName = typeParameter.typeName.name;
           // @ts-ignore: Assume that types from external packages are correct
-          typeParameter.typeName.name = `${data.entity.classifiedName}Signature`;
+          typeParameter.typeName.name = identifier;
 
           return false;
         }

--- a/src/steps/create-signatures/update-constructor.ts
+++ b/src/steps/create-signatures/update-constructor.ts
@@ -15,17 +15,16 @@ export function updateConstructor(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitClassMethod(path) {
-      if (path.node.kind !== 'constructor') {
-        return false;
-      }
-
-      if (path.node.params.length !== 2) {
+      if (path.node.kind !== 'constructor' || path.node.params.length !== 2) {
         return false;
       }
 
       const args = path.node.params[1]!;
 
-      // @ts-ignore: Assume that types from external packages are correct
+      if (args.type !== 'Identifier') {
+        return false;
+      }
+
       args.typeAnnotation = AST.builders.tsTypeAnnotation(
         AST.builders.tsIndexedAccessType(
           AST.builders.tsTypeReference(

--- a/src/steps/create-signatures/update-constructor.ts
+++ b/src/steps/create-signatures/update-constructor.ts
@@ -8,12 +8,7 @@ type Options = {
   };
 };
 
-export function updateConstructor(
-  file: string,
-  options: Options,
-): {
-  newFile: string;
-} {
+export function updateConstructor(file: string, options: Options): string {
   const traverse = AST.traverse(true);
 
   const { data } = options;
@@ -44,7 +39,5 @@ export function updateConstructor(
     },
   });
 
-  return {
-    newFile: AST.print(ast),
-  };
+  return AST.print(ast);
 }

--- a/src/steps/create-signatures/update-references.ts
+++ b/src/steps/create-signatures/update-references.ts
@@ -21,8 +21,10 @@ export function updateReferences(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitTSInterfaceDeclaration(path) {
-      // @ts-ignore: Assume that types from external packages are correct
-      if (path.node.id.name !== interfaceName) {
+      if (
+        path.node.id.type !== 'Identifier' ||
+        path.node.id.name !== interfaceName
+      ) {
         return false;
       }
 
@@ -36,17 +38,17 @@ export function updateReferences(file: string, options: Options): string {
     },
 
     visitTSTypeAliasDeclaration(path) {
-      // @ts-ignore: Assume that types from external packages are correct
-      if (path.node.id.name !== interfaceName) {
+      if (
+        path.node.id.type !== 'Identifier' ||
+        path.node.id.name !== interfaceName ||
+        path.node.typeAnnotation.type !== 'TSTypeLiteral'
+      ) {
         return false;
       }
 
-      // @ts-ignore: Assume that types from external packages are correct
       const members = isSignature(path.node.typeAnnotation.members)
-        ? // @ts-ignore: Assume that types from external packages are correct
-          path.node.typeAnnotation.members
-        : // @ts-ignore: Assume that types from external packages are correct
-          builderConvertArgsToSignature(path.node.typeAnnotation.members);
+        ? path.node.typeAnnotation.members
+        : builderConvertArgsToSignature(path.node.typeAnnotation.members);
 
       const identifier = `${data.entity.classifiedName}Signature`;
 

--- a/src/utils/components/get-base-component.ts
+++ b/src/utils/components/get-base-component.ts
@@ -17,8 +17,7 @@ export function getBaseComponent(file: string): BaseComponent {
         case '@ember/component':
         case '@ember/component/template-only':
         case '@glimmer/component': {
-          // @ts-ignore: Assume that types from external packages are correct
-          const defaultImport = path.node.specifiers.find(({ type }) => {
+          const defaultImport = path.node.specifiers!.find(({ type }) => {
             return type === 'ImportDefaultSpecifier';
           });
 
@@ -26,8 +25,7 @@ export function getBaseComponent(file: string): BaseComponent {
             return false;
           }
 
-          // @ts-ignore: Assume that types from external packages are correct
-          baseComponentName = defaultImport.local.name;
+          baseComponentName = defaultImport.local!.name as string;
           importPath = path.node.source.value as string;
 
           return false;


### PR DESCRIPTION
## Description

Currently, the codemod fails to move the signature "outside" when the component has already passed a valid signature.

```ts
import templateOnlyComponent from '@ember/component/template-only';

type MenuItem = {
  label: string;
  route: string;
};

/* The input code remains the same */
const NavigationMenuComponent = templateOnlyComponent<{
  Args: {
    menuItems: MenuItem[];
    name?: string;
  };
}>();

export default NavigationMenuComponent;

declare module '@glint/environment-ember-loose/registry' {
  export default interface Registry {
    NavigationMenu: typeof NavigationMenuComponent;
  }
}
```

I updated `create-signatures` so that we will have instead,

```ts
import templateOnlyComponent from '@ember/component/template-only';

type MenuItem = {
  label: string;
  route: string;
};

interface NavigationMenuSignature {
  Args: {
    menuItems: MenuItem[];
    name?: string;
  };
}

const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

export default NavigationMenuComponent;

declare module '@glint/environment-ember-loose/registry' {
  export default interface Registry {
    NavigationMenu: typeof NavigationMenuComponent;
  }
}
```
