### PR TITLE
Filled out Signature['Element']

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   createRegistries,
   createSignatures,
   createTemplateOnlyComponents,
+  updateSignatures,
 } from './steps/index.js';
 import type { CodemodOptions } from './types/index.js';
 
@@ -13,8 +14,13 @@ export function runCodemod(codemodOptions: CodemodOptions): void {
   // Prepare for migration
   const context = analyzeProject(options);
 
-  // Update components
+  // Update components without backing class
   createTemplateOnlyComponents(context, options);
+
+  // Update components with backing class
   createSignatures(context, options);
   createRegistries(context, options);
+
+  // Fill out signatures
+  updateSignatures(context, options);
 }

--- a/src/steps/analyze-project/find-element.ts
+++ b/src/steps/analyze-project/find-element.ts
@@ -29,5 +29,7 @@ export function findElement(file: string | undefined): string[] | undefined {
     return;
   }
 
-  return elementTags.map(getHtmlInterface).sort();
+  const htmlInterfaces = elementTags.map(getHtmlInterface);
+
+  return Array.from(new Set(htmlInterfaces)).sort();
 }

--- a/src/steps/create-signatures/builders.ts
+++ b/src/steps/create-signatures/builders.ts
@@ -8,25 +8,6 @@ export function builderConvertArgsToSignature(nodes: unknown[] = []) {
       AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(nodes)),
       false,
     ),
-
-    // AST.builders.tsPropertySignature(
-    //   AST.builders.identifier('Blocks'),
-    //   AST.builders.tsTypeAnnotation(
-    //     AST.builders.tsTypeLiteral([
-    //       AST.builders.tsPropertySignature(
-    //         AST.builders.identifier('default'),
-    //         AST.builders.tsTypeAnnotation(AST.builders.tsTupleType([])),
-    //       ),
-    //     ]),
-    //   ),
-    //   false,
-    // ),
-
-    // AST.builders.tsPropertySignature(
-    //   AST.builders.identifier('Element'),
-    //   AST.builders.tsTypeAnnotation(AST.builders.tsNullKeyword()),
-    //   false,
-    // ),
   ];
 }
 

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -3,3 +3,4 @@ export * from './create-options.js';
 export * from './create-registries.js';
 export * from './create-signatures.js';
 export * from './create-template-only-components.js';
+export * from './update-signatures.js';

--- a/src/steps/update-signatures.ts
+++ b/src/steps/update-signatures.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  createFiles,
+  type FileContent,
+  type FilePath,
+} from '@codemod-utils/files';
+
+import type { Context, Options } from '../types/index.js';
+import {
+  getComponentFilePath,
+  transformEntityName,
+} from '../utils/components.js';
+import { updateSignature } from './update-signatures/index.js';
+
+export function updateSignatures(context: Context, options: Options): void {
+  const { projectRoot } = options;
+
+  const fileMap = new Map<FilePath, FileContent>();
+
+  for (const [entityName, signature] of context.signatureMap) {
+    const filePath = getComponentFilePath(options)(entityName);
+
+    const data = {
+      entity: transformEntityName(entityName),
+      signature,
+    };
+
+    try {
+      let file = readFileSync(join(projectRoot, filePath), 'utf8');
+      file = updateSignature(file, data);
+
+      fileMap.set(filePath, file);
+    } catch (error) {
+      let message = `WARNING: updateSignatures could not update \`${filePath}\`. Please update the file manually.`;
+
+      if (error instanceof Error) {
+        message += ` (${error.message})`;
+      }
+
+      console.warn(`${message}\n`);
+    }
+  }
+
+  createFiles(fileMap, options);
+}

--- a/src/steps/update-signatures/builders.ts
+++ b/src/steps/update-signatures/builders.ts
@@ -1,0 +1,23 @@
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { Signature } from '../../types/index.js';
+
+export function builderCreateElementNode(signature: Signature) {
+  if (signature.Element === undefined) {
+    return;
+  }
+
+  return AST.builders.tsPropertySignature(
+    AST.builders.identifier('Element'),
+    AST.builders.tsTypeAnnotation(
+      AST.builders.tsUnionType(
+        signature.Element.map((htmlInterface) => {
+          return AST.builders.tsTypeReference(
+            AST.builders.identifier(htmlInterface),
+          );
+        }),
+      ),
+    ),
+    false,
+  );
+}

--- a/src/steps/update-signatures/index.ts
+++ b/src/steps/update-signatures/index.ts
@@ -1,0 +1,1 @@
+export * from './update-signature.js';

--- a/src/steps/update-signatures/update-signature.ts
+++ b/src/steps/update-signatures/update-signature.ts
@@ -1,0 +1,55 @@
+import { AST } from '@codemod-utils/ast-javascript';
+
+import type { Signature } from '../../types/index.js';
+import type { TransformedEntityName } from '../../utils/components.js';
+import { builderCreateElementNode } from './builders.js';
+
+type Data = {
+  entity: TransformedEntityName;
+  signature: Signature;
+};
+
+function getBodyNode(node: unknown, key: 'Args' | 'Blocks' | 'Element') {
+  // @ts-ignore: Assume that types from external packages are correct
+  return node.body.body.find((node) => {
+    if (node.type !== 'TSPropertySignature' || node.key.type !== 'Identifier') {
+      return false;
+    }
+
+    return node.key.name === key;
+  });
+}
+
+export function updateSignature(file: string, data: Data): string {
+  const traverse = AST.traverse(true);
+
+  const identifier = `${data.entity.classifiedName}Signature`;
+
+  const ast = traverse(file, {
+    visitTSInterfaceDeclaration(path) {
+      if (
+        path.node.id.type !== 'Identifier' ||
+        path.node.id.name !== identifier
+      ) {
+        return false;
+      }
+
+      const ArgsNode = getBodyNode(path.node, 'Args');
+
+      const BlocksNode = getBodyNode(path.node, 'Blocks');
+
+      const ElementNode =
+        getBodyNode(path.node, 'Element') ??
+        builderCreateElementNode(data.signature);
+
+      return AST.builders.tsInterfaceDeclaration(
+        AST.builders.identifier(identifier),
+        AST.builders.tsInterfaceBody(
+          [ArgsNode, BlocksNode, ElementNode].filter(Boolean),
+        ),
+      );
+    },
+  });
+
+  return AST.print(ast);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,4 +25,11 @@ type Options = {
   src: string;
 };
 
-export type { CodemodOptions, Context, ExtensionMap, Options, SignatureMap };
+export type {
+  CodemodOptions,
+  Context,
+  ExtensionMap,
+  Options,
+  Signature,
+  SignatureMap,
+};

--- a/tests/fixtures/ember-container-query-glint/input/src/components/tracks.hbs
+++ b/tests/fixtures/ember-container-query-glint/input/src/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query-glint/output/src/components/tracks.hbs
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query-glint/output/src/components/tracks.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/tracks.ts
@@ -6,6 +6,7 @@ interface TracksSignature {
   Args: {
     tracks?: Track[];
   };
+  Element: HTMLElement;
 }
 
 const TracksComponent = templateOnlyComponent<TracksSignature>();

--- a/tests/fixtures/ember-container-query-nested/input/app/components/tracks/index.hbs
+++ b/tests/fixtures/ember-container-query-nested/input/app/components/tracks/index.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query-nested/output/app/components/navigation-menu/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/navigation-menu/index.ts
@@ -10,6 +10,7 @@ interface NavigationMenuSignature {
     menuItems: MenuItem[];
     name?: string;
   };
+  Element: HTMLElement;
 }
 
 const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/products/product/card/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/products/product/card/index.ts
@@ -7,6 +7,7 @@ interface ProductsProductCardSignature {
     product: Product;
     redirectTo?: string;
   };
+  Element: HTMLElement;
 }
 
 const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();

--- a/tests/fixtures/ember-container-query-nested/output/app/components/products/product/image/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/products/product/image/index.ts
@@ -5,6 +5,7 @@ interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
+  Element: HTMLDivElement | HTMLImageElement;
 }
 
 class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.hbs
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const TracksComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/list/index.ts
@@ -7,6 +7,7 @@ interface TracksListSignature {
     numColumns?: number;
     tracks?: Track[];
   };
+  Element: HTMLUListElement;
 }
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/table/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/table/index.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
+  Element: HTMLTableElement;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/index.ts
@@ -9,6 +9,7 @@ interface UiFormSignature {
     instructions?: string;
     title?: string;
   };
+  Element: HTMLFormElement;
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/page/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/page/index.ts
@@ -4,6 +4,7 @@ interface UiPageSignature {
   Args: {
     title: string;
   };
+  Element: HTMLDivElement;
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/index.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/ember-container-query-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/ember-container-query-no-args/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/navigation-menu.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface NavigationMenuSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/card.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface ProductsProductCardSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/image.ts
@@ -3,6 +3,7 @@ import config from 'docs-app/config/environment';
 
 interface ProductsProductImageSignature {
   Args: {};
+  Element: HTMLDivElement | HTMLImageElement;
 }
 
 class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 interface TracksSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 export default class TracksComponent extends Component<TracksSignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 interface TracksListSignature {
   Args: {};
+  Element: HTMLUListElement;
 }
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/table.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
+  Element: HTMLTableElement;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 interface UiFormSignature {
   Args: {};
+  Element: HTMLFormElement;
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/page.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 interface UiPageSignature {
   Args: {};
+  Element: HTMLDivElement;
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/ember-container-query/input/app/components/tracks.hbs
+++ b/tests/fixtures/ember-container-query/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/navigation-menu.ts
@@ -10,6 +10,7 @@ interface NavigationMenuSignature {
     menuItems: MenuItem[];
     name?: string;
   };
+  Element: HTMLElement;
 }
 
 const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();

--- a/tests/fixtures/ember-container-query/output/app/components/products/product/card.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/products/product/card.ts
@@ -7,6 +7,7 @@ interface ProductsProductCardSignature {
     product: Product;
     redirectTo?: string;
   };
+  Element: HTMLElement;
 }
 
 const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();

--- a/tests/fixtures/ember-container-query/output/app/components/products/product/image.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/products/product/image.ts
@@ -5,6 +5,7 @@ interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
+  Element: HTMLDivElement | HTMLImageElement;
 }
 
 class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/tracks.hbs
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/ember-container-query/output/app/components/tracks.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const TracksComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks/list.ts
@@ -7,6 +7,7 @@ interface TracksListSignature {
     numColumns?: number;
     tracks?: Track[];
   };
+  Element: HTMLUListElement;
 }
 
 export default class TracksListComponent extends Component<TracksListSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks/table.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
   Args: {};
+  Element: HTMLTableElement;
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form.ts
@@ -9,6 +9,7 @@ interface UiFormSignature {
     instructions?: string;
     title?: string;
   };
+  Element: HTMLFormElement;
 }
 
 export default class UiFormComponent extends Component<UiFormSignature> {

--- a/tests/fixtures/ember-container-query/output/app/components/ui/page.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/page.ts
@@ -4,6 +4,7 @@ interface UiPageSignature {
   Args: {
     title: string;
   };
+  Element: HTMLDivElement;
 }
 
 export default class UiPageComponent extends Component<UiPageSignature> {}

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();

--- a/tests/fixtures/steps/create-registries/has-declaration-file/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-registries/has-declaration-file/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-registries/has-declaration-file/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-registries/has-declaration-file/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-registries/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-registries/has-no-args/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-registries/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-registries/has-no-args/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-signatures/has-no-args/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-declaration-file/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-declaration-file/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-declaration-file/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-declaration-file/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/create-template-only-components/has-no-args/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}} ...attributes>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/navigation-menu.ts
@@ -1,0 +1,24 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type MenuItem = {
+  label: string;
+  route: string;
+};
+
+interface NavigationMenuSignature {
+  Args: {
+    menuItems: MenuItem[];
+    name?: string;
+  };
+}
+
+const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();
+
+export default NavigationMenuComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'NavigationMenu': typeof NavigationMenuComponent;
+    'navigation-menu': typeof NavigationMenuComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/card.hbs
@@ -1,0 +1,41 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+  ...attributes
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/card.ts
@@ -1,0 +1,21 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+import type { Product } from '../../../data/products';
+
+interface ProductsProductCardSignature {
+  Args: {
+    product: Product;
+    redirectTo?: string;
+  };
+}
+
+const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();
+
+export default ProductsProductCardComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Card': typeof ProductsProductCardComponent;
+    'products/product/card': typeof ProductsProductCardComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/image.hbs
@@ -1,0 +1,13 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image" ...attributes></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+    ...attributes
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/products/product/image.ts
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageSignature {
+  Args: {
+    src: string;
+  };
+}
+
+class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImageComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Image': typeof ProductsProductImageComponent;
+    'products/product/image': typeof ProductsProductImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/tracks/list.hbs
@@ -1,0 +1,32 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+  ...attributes
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/tracks/list.ts
@@ -1,0 +1,35 @@
+import Component from '@glimmer/component';
+
+import type { Track } from '../../data/album';
+
+interface TracksListSignature {
+  Args: {
+    numColumns?: number;
+    tracks?: Track[];
+  };
+}
+
+export default class TracksListComponent extends Component<TracksListSignature> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks::List': typeof TracksListComponent;
+    'tracks/list': typeof TracksListComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form.hbs
@@ -1,0 +1,56 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+  ...attributes
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form.ts
@@ -1,0 +1,38 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormSignature {
+  Args: {
+    data?: Record<string, any>;
+    instructions?: string;
+    title?: string;
+  };
+}
+
+export default class UiFormComponent extends Component<UiFormSignature> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form': typeof UiFormComponent;
+    'ui/form': typeof UiFormComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/checkbox.ts
@@ -1,0 +1,60 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormCheckboxSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isInline?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  };
+}
+
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Checkbox': typeof UiFormCheckboxComponent;
+    'ui/form/checkbox': typeof UiFormCheckboxComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/field.ts
@@ -1,0 +1,21 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldSignature {
+  Args: {
+    errorMessage?: string;
+    isInline?: boolean;
+    isWide?: boolean;
+  };
+}
+
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
+  inputId = guidFor(this);
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Field': typeof UiFormFieldComponent;
+    'ui/form/field': typeof UiFormFieldComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/input.ts
@@ -1,0 +1,57 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormInputSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+    placeholder?: string;
+    type?: string;
+  };
+}
+
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Input': typeof UiFormInputComponent;
+    'ui/form/input': typeof UiFormInputComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/form/textarea.ts
@@ -1,0 +1,52 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormTextareaSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+    placeholder?: string;
+  };
+}
+
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Textarea': typeof UiFormTextareaComponent;
+    'ui/form/textarea': typeof UiFormTextareaComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/page.hbs
@@ -1,0 +1,14 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div
+    id="main-content"
+    local-class="body"
+    tabindex="-1"
+    ...attributes
+  >
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/page.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/ui/page.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+interface UiPageSignature {
+  Args: {
+    title: string;
+  };
+}
+
+export default class UiPageComponent extends Component<UiPageSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Page': typeof UiPageComponent;
+    'ui/page': typeof UiPageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-1.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+  ...attributes
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-1.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
+
+export default WidgetsWidget1Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget1': typeof WidgetsWidget1Component;
+    'widgets/widget-1': typeof WidgetsWidget1Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2.ts
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2': typeof WidgetsWidget2Component;
+    'widgets/widget-2': typeof WidgetsWidget2Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,60 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+interface WidgetsWidget2CaptionsSignature {
+  Args: {
+    summaries?: Summary[];
+  };
+}
+
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::Captions': typeof WidgetsWidget2CaptionsComponent;
+    'widgets/widget-2/captions': typeof WidgetsWidget2CaptionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2StackedChartSignature {
+  Args: {
+    data: Data[];
+  };
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::StackedChart': typeof WidgetsWidget2StackedChartComponent;
+    'widgets/widget-2/stacked-chart': typeof WidgetsWidget2StackedChartComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3.ts
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3': typeof WidgetsWidget3Component;
+    'widgets/widget-3': typeof WidgetsWidget3Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,30 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
+  Args: {
+    images: Image[];
+  };
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args as WidgetsWidget3TourScheduleResponsiveImageSignature['Args'];
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+    'widgets/widget-3/tour-schedule/responsive-image': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
+
+export default WidgetsWidget4Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4': typeof WidgetsWidget4Component;
+    'widgets/widget-4': typeof WidgetsWidget4Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
+
+export default WidgetsWidget4MemoComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo': typeof WidgetsWidget4MemoComponent;
+    'widgets/widget-4/memo': typeof WidgetsWidget4MemoComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,19 @@
+import templateOnlyComponent from '@ember/component/template-only';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
+
+export default WidgetsWidget4MemoActionsComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Actions': typeof WidgetsWidget4MemoActionsComponent;
+    'widgets/widget-4/memo/actions': typeof WidgetsWidget4MemoActionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
+
+export default WidgetsWidget4MemoBodyComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Body': typeof WidgetsWidget4MemoBodyComponent;
+    'widgets/widget-4/memo/body': typeof WidgetsWidget4MemoBodyComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
+
+export default WidgetsWidget4MemoHeaderComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Header': typeof WidgetsWidget4MemoHeaderComponent;
+    'widgets/widget-4/memo/header': typeof WidgetsWidget4MemoHeaderComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}} ...attributes>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/navigation-menu.ts
@@ -1,0 +1,25 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+type MenuItem = {
+  label: string;
+  route: string;
+};
+
+interface NavigationMenuSignature {
+  Args: {
+    menuItems: MenuItem[];
+    name?: string;
+  };
+  Element: HTMLElement;
+}
+
+const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();
+
+export default NavigationMenuComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'NavigationMenu': typeof NavigationMenuComponent;
+    'navigation-menu': typeof NavigationMenuComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/card.hbs
@@ -1,0 +1,41 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+  ...attributes
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/card.ts
@@ -1,0 +1,22 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+import type { Product } from '../../../data/products';
+
+interface ProductsProductCardSignature {
+  Args: {
+    product: Product;
+    redirectTo?: string;
+  };
+  Element: HTMLElement;
+}
+
+const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();
+
+export default ProductsProductCardComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Card': typeof ProductsProductCardComponent;
+    'products/product/card': typeof ProductsProductCardComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/image.hbs
@@ -1,0 +1,13 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image" ...attributes></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+    ...attributes
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/products/product/image.ts
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageSignature {
+  Args: {
+    src: string;
+  };
+  Element: HTMLDivElement | HTMLImageElement;
+}
+
+class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImageComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Image': typeof ProductsProductImageComponent;
+    'products/product/image': typeof ProductsProductImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/tracks/list.hbs
@@ -1,0 +1,32 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+  ...attributes
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/tracks/list.ts
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+
+import type { Track } from '../../data/album';
+
+interface TracksListSignature {
+  Args: {
+    numColumns?: number;
+    tracks?: Track[];
+  };
+  Element: HTMLUListElement;
+}
+
+export default class TracksListComponent extends Component<TracksListSignature> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks::List': typeof TracksListComponent;
+    'tracks/list': typeof TracksListComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form.hbs
@@ -1,0 +1,56 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+  ...attributes
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form.ts
@@ -1,0 +1,39 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormSignature {
+  Args: {
+    data?: Record<string, any>;
+    instructions?: string;
+    title?: string;
+  };
+  Element: HTMLFormElement;
+}
+
+export default class UiFormComponent extends Component<UiFormSignature> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form': typeof UiFormComponent;
+    'ui/form': typeof UiFormComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/checkbox.ts
@@ -1,0 +1,60 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormCheckboxSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isInline?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+  };
+}
+
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Checkbox': typeof UiFormCheckboxComponent;
+    'ui/form/checkbox': typeof UiFormCheckboxComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/field.ts
@@ -1,0 +1,21 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldSignature {
+  Args: {
+    errorMessage?: string;
+    isInline?: boolean;
+    isWide?: boolean;
+  };
+}
+
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
+  inputId = guidFor(this);
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Field': typeof UiFormFieldComponent;
+    'ui/form/field': typeof UiFormFieldComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/input.ts
@@ -1,0 +1,57 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormInputSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+    placeholder?: string;
+    type?: string;
+  };
+}
+
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Input': typeof UiFormInputComponent;
+    'ui/form/input': typeof UiFormInputComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/form/textarea.ts
@@ -1,0 +1,52 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormTextareaSignature {
+  Args: {
+    changeset: Record<string, any>;
+    isDisabled?: boolean;
+    isReadOnly?: boolean;
+    isRequired?: boolean;
+    isWide?: boolean;
+    key: string;
+    label: string;
+    onUpdate: ({ key, value }: { key: string; value: any }) => void;
+    placeholder?: string;
+  };
+}
+
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Textarea': typeof UiFormTextareaComponent;
+    'ui/form/textarea': typeof UiFormTextareaComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/page.hbs
@@ -1,0 +1,14 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div
+    id="main-content"
+    local-class="body"
+    tabindex="-1"
+    ...attributes
+  >
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/ui/page.ts
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+
+interface UiPageSignature {
+  Args: {
+    title: string;
+  };
+  Element: HTMLDivElement;
+}
+
+export default class UiPageComponent extends Component<UiPageSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Page': typeof UiPageComponent;
+    'ui/page': typeof UiPageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-1.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+  ...attributes
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-1.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget1Signature {
+  Args: {};
+  Element: HTMLElement;
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
+
+export default WidgetsWidget1Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget1': typeof WidgetsWidget1Component;
+    'widgets/widget-1': typeof WidgetsWidget1Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2.ts
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2': typeof WidgetsWidget2Component;
+    'widgets/widget-2': typeof WidgetsWidget2Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,60 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+interface WidgetsWidget2CaptionsSignature {
+  Args: {
+    summaries?: Summary[];
+  };
+}
+
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::Captions': typeof WidgetsWidget2CaptionsComponent;
+    'widgets/widget-2/captions': typeof WidgetsWidget2CaptionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2StackedChartSignature {
+  Args: {
+    data: Data[];
+  };
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::StackedChart': typeof WidgetsWidget2StackedChartComponent;
+    'widgets/widget-2/stacked-chart': typeof WidgetsWidget2StackedChartComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3.ts
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3': typeof WidgetsWidget3Component;
+    'widgets/widget-3': typeof WidgetsWidget3Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,30 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
+  Args: {
+    images: Image[];
+  };
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args as WidgetsWidget3TourScheduleResponsiveImageSignature['Args'];
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+    'widgets/widget-3/tour-schedule/responsive-image': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
+
+export default WidgetsWidget4Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4': typeof WidgetsWidget4Component;
+    'widgets/widget-4': typeof WidgetsWidget4Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
+
+export default WidgetsWidget4MemoComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo': typeof WidgetsWidget4MemoComponent;
+    'widgets/widget-4/memo': typeof WidgetsWidget4MemoComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,19 @@
+import templateOnlyComponent from '@ember/component/template-only';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
+
+export default WidgetsWidget4MemoActionsComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Actions': typeof WidgetsWidget4MemoActionsComponent;
+    'widgets/widget-4/memo/actions': typeof WidgetsWidget4MemoActionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoBodySignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
+
+export default WidgetsWidget4MemoBodyComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Body': typeof WidgetsWidget4MemoBodyComponent;
+    'widgets/widget-4/memo/body': typeof WidgetsWidget4MemoBodyComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/update-signatures/has-backing-class/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import type { QueryResults } from 'ember-container-query';
+
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {
+    cqFeatures?: QueryResults<'small' | 'large' | 'short'>;
+  };
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
+
+export default WidgetsWidget4MemoHeaderComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Header': typeof WidgetsWidget4MemoHeaderComponent;
+    'widgets/widget-4/memo/header': typeof WidgetsWidget4MemoHeaderComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.d.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.d.ts
@@ -1,0 +1,5 @@
+import type { Track } from '../data/album';
+
+export interface TracksComponentArgs {
+  tracks?: Array<Track>;
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/tracks.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface TracksSignature {
+  Args: {};
+}
+
+const TracksComponent =
+  templateOnlyComponent<TracksSignature>();
+
+export default TracksComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks': typeof TracksComponent;
+    'tracks': typeof TracksComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.d.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.d.ts
@@ -1,0 +1,5 @@
+import type { Concert } from '../../../data/concert';
+
+export interface WidgetsWidget3TourScheduleComponentArgs {
+  concert: Concert;
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.hbs
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.hbs
@@ -1,0 +1,31 @@
+<ContainerQuery
+  @features={{hash small=(width max=400)}}
+  @dataAttributePrefix="cq"
+  local-class="container"
+>
+  <div local-class="splash">
+    <div local-class="splash-image-container">
+      {{#if @concert.images}}
+        <WidgetsWidget3TourScheduleResponsiveImage
+          @images={{@concert.images}}
+        />
+
+      {{else}}
+        <div local-class="placeholder-image"></div>
+
+      {{/if}}
+    </div>
+
+    <div local-class="concert-date-container">
+      <time local-class="concert-date">
+        {{@concert.date}}
+      </time>
+    </div>
+
+    <div local-class="venue-name-container">
+      <a href="#" local-class="concert-link">
+        <div local-class="venue-name">{{@concert.name}}</div>
+      </a>
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget3TourScheduleSignature {
+  Args: {};
+}
+
+const WidgetsWidget3TourScheduleComponent =
+  templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
+
+export default WidgetsWidget3TourScheduleComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
+    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.d.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.d.ts
@@ -1,0 +1,5 @@
+import type { Track } from '../data/album';
+
+export interface TracksComponentArgs {
+  tracks?: Array<Track>;
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.ts
@@ -2,6 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 const TracksComponent =

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface TracksSignature {
+  Args: {};
+}
+
+const TracksComponent =
+  templateOnlyComponent<TracksSignature>();
+
+export default TracksComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks': typeof TracksComponent;
+    'tracks': typeof TracksComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.d.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.d.ts
@@ -1,0 +1,5 @@
+import type { Concert } from '../../../data/concert';
+
+export interface WidgetsWidget3TourScheduleComponentArgs {
+  concert: Concert;
+}

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.hbs
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.hbs
@@ -1,0 +1,31 @@
+<ContainerQuery
+  @features={{hash small=(width max=400)}}
+  @dataAttributePrefix="cq"
+  local-class="container"
+>
+  <div local-class="splash">
+    <div local-class="splash-image-container">
+      {{#if @concert.images}}
+        <WidgetsWidget3TourScheduleResponsiveImage
+          @images={{@concert.images}}
+        />
+
+      {{else}}
+        <div local-class="placeholder-image"></div>
+
+      {{/if}}
+    </div>
+
+    <div local-class="concert-date-container">
+      <time local-class="concert-date">
+        {{@concert.date}}
+      </time>
+    </div>
+
+    <div local-class="venue-name-container">
+      <a href="#" local-class="concert-link">
+        <div local-class="venue-name">{{@concert.name}}</div>
+      </a>
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget3TourScheduleSignature {
+  Args: {};
+}
+
+const WidgetsWidget3TourScheduleComponent =
+  templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
+
+export default WidgetsWidget3TourScheduleComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
+    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/ui/form/information.hbs
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/ui/form/information.hbs
@@ -1,0 +1,23 @@
+{{#if (strict-or @title @instructions)}}
+  <div local-class="container">
+    {{#if @title}}
+      <div
+        data-test-title
+        id={{concat @formId "-title"}}
+        local-class="title"
+      >
+        {{@title}}
+      </div>
+    {{/if}}
+
+    {{#if @instructions}}
+      <p
+        data-test-instructions
+        id={{concat @formId "-instructions"}}
+        local-class="instructions"
+      >
+        {{@instructions}}
+      </p>
+    {{/if}}
+  </div>
+{{/if}}

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/ui/form/information.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface UiFormInformationSignature {
+  Args: {};
+}
+
+const UiFormInformationComponent =
+  templateOnlyComponent<UiFormInformationSignature>();
+
+export default UiFormInformationComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Information': typeof UiFormInformationComponent;
+    'ui/form/information': typeof UiFormInformationComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.hbs
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.hbs
@@ -1,0 +1,34 @@
+<ContainerQuery
+  @features={{hash
+    large=(cq-width min=224)
+    tall=(cq-height min=120)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  {{#let
+    (strict-and CQ.features.large CQ.features.tall)
+    as |showFullText|
+  }}
+    <div data-test-call-to-action local-class="call-to-action">
+      {{#if showFullText}}
+        <p>What will <em>you</em> create with</p>
+      {{/if}}
+
+      <p local-class="highlight">
+        <a
+          href="https://github.com/ijlee2/ember-container-query"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ember-container-query
+        </a>
+      </p>
+
+      {{#if showFullText}}
+        <p>?</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget5Signature {
+  Args: {};
+}
+
+const WidgetsWidget5Component =
+  templateOnlyComponent<WidgetsWidget5Signature>();
+
+export default WidgetsWidget5Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget5': typeof WidgetsWidget5Component;
+    'widgets/widget-5': typeof WidgetsWidget5Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/ui/form/information.hbs
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/ui/form/information.hbs
@@ -1,0 +1,23 @@
+{{#if (strict-or @title @instructions)}}
+  <div local-class="container">
+    {{#if @title}}
+      <div
+        data-test-title
+        id={{concat @formId "-title"}}
+        local-class="title"
+      >
+        {{@title}}
+      </div>
+    {{/if}}
+
+    {{#if @instructions}}
+      <p
+        data-test-instructions
+        id={{concat @formId "-instructions"}}
+        local-class="instructions"
+      >
+        {{@instructions}}
+      </p>
+    {{/if}}
+  </div>
+{{/if}}

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface UiFormInformationSignature {
+  Args: {};
+}
+
+const UiFormInformationComponent =
+  templateOnlyComponent<UiFormInformationSignature>();
+
+export default UiFormInformationComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Information': typeof UiFormInformationComponent;
+    'ui/form/information': typeof UiFormInformationComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.hbs
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.hbs
@@ -1,0 +1,34 @@
+<ContainerQuery
+  @features={{hash
+    large=(cq-width min=224)
+    tall=(cq-height min=120)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  {{#let
+    (strict-and CQ.features.large CQ.features.tall)
+    as |showFullText|
+  }}
+    <div data-test-call-to-action local-class="call-to-action">
+      {{#if showFullText}}
+        <p>What will <em>you</em> create with</p>
+      {{/if}}
+
+      <p local-class="highlight">
+        <a
+          href="https://github.com/ijlee2/ember-container-query"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ember-container-query
+        </a>
+      </p>
+
+      {{#if showFullText}}
+        <p>?</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget5Signature {
+  Args: {};
+}
+
+const WidgetsWidget5Component =
+  templateOnlyComponent<WidgetsWidget5Signature>();
+
+export default WidgetsWidget5Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget5': typeof WidgetsWidget5Component;
+    'widgets/widget-5': typeof WidgetsWidget5Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}} ...attributes>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/navigation-menu.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface NavigationMenuSignature {
+  Args: {};
+}
+
+const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();
+
+export default NavigationMenuComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'NavigationMenu': typeof NavigationMenuComponent;
+    'navigation-menu': typeof NavigationMenuComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/card.hbs
@@ -1,0 +1,41 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+  ...attributes
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/card.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface ProductsProductCardSignature {
+  Args: {};
+}
+
+const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();
+
+export default ProductsProductCardComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Card': typeof ProductsProductCardComponent;
+    'products/product/card': typeof ProductsProductCardComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/image.hbs
@@ -1,0 +1,13 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image" ...attributes></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+    ...attributes
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/products/product/image.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageSignature {
+  Args: {};
+}
+
+class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImageComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Image': typeof ProductsProductImageComponent;
+    'products/product/image': typeof ProductsProductImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface TracksSignature {
+  Args: {};
+}
+
+export default class TracksComponent extends Component<TracksSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks': typeof TracksComponent;
+    'tracks': typeof TracksComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks/list.hbs
@@ -1,0 +1,32 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+  ...attributes
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/tracks/list.ts
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+
+interface TracksListSignature {
+  Args: {};
+}
+
+export default class TracksListComponent extends Component<TracksListSignature> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks::List': typeof TracksListComponent;
+    'tracks/list': typeof TracksListComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form.hbs
@@ -1,0 +1,56 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+  ...attributes
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form.ts
@@ -1,0 +1,34 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormSignature {
+  Args: {};
+}
+
+export default class UiFormComponent extends Component<UiFormSignature> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form': typeof UiFormComponent;
+    'ui/form': typeof UiFormComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/checkbox.ts
@@ -1,0 +1,50 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormCheckboxSignature {
+  Args: {};
+}
+
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Checkbox': typeof UiFormCheckboxComponent;
+    'ui/form/checkbox': typeof UiFormCheckboxComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/field.ts
@@ -1,0 +1,17 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldSignature {
+  Args: {};
+}
+
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
+  inputId = guidFor(this);
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Field': typeof UiFormFieldComponent;
+    'ui/form/field': typeof UiFormFieldComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/input.ts
@@ -1,0 +1,46 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormInputSignature {
+  Args: {};
+}
+
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Input': typeof UiFormInputComponent;
+    'ui/form/input': typeof UiFormInputComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/form/textarea.ts
@@ -1,0 +1,42 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormTextareaSignature {
+  Args: {};
+}
+
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Textarea': typeof UiFormTextareaComponent;
+    'ui/form/textarea': typeof UiFormTextareaComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/page.hbs
@@ -1,0 +1,14 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div
+    id="main-content"
+    local-class="body"
+    tabindex="-1"
+    ...attributes
+  >
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/page.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/ui/page.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface UiPageSignature {
+  Args: {};
+}
+
+export default class UiPageComponent extends Component<UiPageSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Page': typeof UiPageComponent;
+    'ui/page': typeof UiPageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-1.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+  ...attributes
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-1.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget1Signature {
+  Args: {};
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
+
+export default WidgetsWidget1Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget1': typeof WidgetsWidget1Component;
+    'widgets/widget-1': typeof WidgetsWidget1Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2.ts
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2': typeof WidgetsWidget2Component;
+    'widgets/widget-2': typeof WidgetsWidget2Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,58 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+interface WidgetsWidget2CaptionsSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::Captions': typeof WidgetsWidget2CaptionsComponent;
+    'widgets/widget-2/captions': typeof WidgetsWidget2CaptionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget2StackedChartSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::StackedChart': typeof WidgetsWidget2StackedChartComponent;
+    'widgets/widget-2/stacked-chart': typeof WidgetsWidget2StackedChartComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3.ts
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3': typeof WidgetsWidget3Component;
+    'widgets/widget-3': typeof WidgetsWidget3Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+    'widgets/widget-3/tour-schedule/responsive-image': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
+
+export default WidgetsWidget4Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4': typeof WidgetsWidget4Component;
+    'widgets/widget-4': typeof WidgetsWidget4Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
+
+export default WidgetsWidget4MemoComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo': typeof WidgetsWidget4MemoComponent;
+    'widgets/widget-4/memo': typeof WidgetsWidget4MemoComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
+
+export default WidgetsWidget4MemoActionsComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Actions': typeof WidgetsWidget4MemoActionsComponent;
+    'widgets/widget-4/memo/actions': typeof WidgetsWidget4MemoActionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget4MemoBodySignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
+
+export default WidgetsWidget4MemoBodyComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Body': typeof WidgetsWidget4MemoBodyComponent;
+    'widgets/widget-4/memo/body': typeof WidgetsWidget4MemoBodyComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/input/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
+
+export default WidgetsWidget4MemoHeaderComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Header': typeof WidgetsWidget4MemoHeaderComponent;
+    'widgets/widget-4/memo/header': typeof WidgetsWidget4MemoHeaderComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/navigation-menu.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/navigation-menu.hbs
@@ -1,0 +1,15 @@
+<nav aria-label={{@name}} data-test-nav={{@name}} ...attributes>
+  <ul local-class="list">
+    {{#each @menuItems as |menuItem|}}
+      <li local-class="item">
+        <LinkTo
+          @route={{menuItem.route}}
+          data-test-link={{menuItem.label}}
+          local-class="link"
+        >
+          {{menuItem.label}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/navigation-menu.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface NavigationMenuSignature {
+  Args: {};
+  Element: HTMLElement;
+}
+
+const NavigationMenuComponent = templateOnlyComponent<NavigationMenuSignature>();
+
+export default NavigationMenuComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'NavigationMenu': typeof NavigationMenuComponent;
+    'navigation-menu': typeof NavigationMenuComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/card.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/card.hbs
@@ -1,0 +1,41 @@
+<ContainerQuery
+  @features={{hash wide=(width min=320)}}
+  @tagName="article"
+  data-test-product-card
+  local-class="container"
+  ...attributes
+>
+  <header local-class="header">
+    <h2 data-test-field="Name" local-class="name">
+      {{@product.name}}
+    </h2>
+  </header>
+
+  <div local-class="image-container">
+    <Products::Product::Image @src={{@product.imageUrl}} />
+  </div>
+
+  <div local-class="body">
+    <p
+      data-test-field="Short Description"
+      local-class="description"
+    >
+      {{@product.shortDescription}}
+    </p>
+
+    <p data-test-field="Price" local-class="price">
+      ${{@product.price}}
+    </p>
+  </div>
+
+  <div local-class="actions">
+    <LinkTo
+      @model={{@product.id}}
+      @route={{@redirectTo}}
+      data-test-link="Learn More"
+      local-class="link"
+    >
+      Learn more
+    </LinkTo>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/card.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface ProductsProductCardSignature {
+  Args: {};
+  Element: HTMLElement;
+}
+
+const ProductsProductCardComponent = templateOnlyComponent<ProductsProductCardSignature>();
+
+export default ProductsProductCardComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Card': typeof ProductsProductCardComponent;
+    'products/product/card': typeof ProductsProductCardComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/image.hbs
@@ -1,0 +1,13 @@
+{{#if this.isTestEnvironment}}
+  <div local-class="placeholder-image" ...attributes></div>
+
+{{else}}
+  <img
+    alt=""
+    local-class="image"
+    role="presentation"
+    src={{@src}}
+    ...attributes
+  />
+
+{{/if}}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/image.ts
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import config from 'docs-app/config/environment';
+
+interface ProductsProductImageSignature {
+  Args: {};
+  Element: HTMLDivElement | HTMLImageElement;
+}
+
+class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
+  isTestEnvironment = config.environment === 'test';
+}
+
+export default ProductsProductImageComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Products::Product::Image': typeof ProductsProductImageComponent;
+    'products/product/image': typeof ProductsProductImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.hbs
@@ -1,0 +1,24 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=480)
+    medium=(width min=480 max=640)
+    large=(width min=640)
+    tall=(height min=320)
+  }}
+  as |CQ|
+>
+  {{#if (strict-and CQ.features.large CQ.features.tall)}}
+    <Tracks::Table @tracks={{@tracks}} />
+
+  {{else}}
+    <Tracks::List
+      @numColumns={{if
+        CQ.features.small
+        1
+        (if CQ.features.medium 2 3)
+      }}
+      @tracks={{@tracks}}
+    />
+
+  {{/if}}
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.hbs
@@ -8,7 +8,10 @@
   as |CQ|
 >
   {{#if (strict-and CQ.features.large CQ.features.tall)}}
-    <Tracks::Table @tracks={{@tracks}} />
+    <Tracks::Table
+      @tracks={{@tracks}}
+      ...attributes
+    />
 
   {{else}}
     <Tracks::List
@@ -18,6 +21,7 @@
         (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
+      ...attributes
     />
 
   {{/if}}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface TracksSignature {
+  Args: {};
+}
+
+export default class TracksComponent extends Component<TracksSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks': typeof TracksComponent;
+    'tracks': typeof TracksComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 interface TracksSignature {
   Args: {};
+  Element: HTMLElement;
 }
 
 export default class TracksComponent extends Component<TracksSignature> {}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.hbs
@@ -1,0 +1,32 @@
+<ul
+  data-test-list="Tracks"
+  data-css-grid="{{this.numRows}} x {{this.numColumns}}"
+  local-class="list"
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
+  ...attributes
+>
+  {{#each @tracks as |track index|}}
+    <li data-test-item local-class="item">
+      <div>
+        {{add index 1}}.
+        <span data-test-field="Title">
+          {{track.name}}
+        </span>
+      </div>
+
+      {{#if track.isExplicit}}
+        <span aria-label="Explicit" data-test-field="Explicit">
+          {{svg-jar
+            "alpha-e-box"
+            class=(local-class "icon-explicit")
+            desc="Letter E, which stands for explicit"
+            role="img"
+          }}
+        </span>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.ts
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+
+interface TracksListSignature {
+  Args: {};
+  Element: HTMLUListElement;
+}
+
+export default class TracksListComponent extends Component<TracksListSignature> {
+  get numColumns(): number {
+    const { numColumns } = this.args;
+
+    return numColumns ?? 1;
+  }
+
+  get numRows(): number {
+    const { tracks } = this.args;
+
+    if (!tracks) {
+      return 0;
+    }
+
+    return Math.ceil(tracks.length / this.numColumns);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Tracks::List': typeof TracksListComponent;
+    'tracks/list': typeof TracksListComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.hbs
@@ -1,0 +1,56 @@
+<form
+  aria-describedby={{if
+    @instructions
+    (concat this.formId "-instructions")
+  }}
+  aria-labelledby={{if @title (concat this.formId "-title")}}
+  data-test-form={{if @title @title ""}}
+  local-class="form"
+  {{on "submit" this.submitForm}}
+  ...attributes
+>
+  <Ui::Form::Information
+    @formId={{this.formId}}
+    @instructions={{@instructions}}
+    @title={{@title}}
+  />
+
+  <ContainerQuery
+    @features={{hash wide=(width min=480)}}
+    as |CQ|
+  >
+    {{yield
+      (hash
+        Checkbox=(component
+          "ui/form/checkbox"
+          changeset=this.changeset
+          isInline=true
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Input=(component
+          "ui/form/input"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+        Textarea=(component
+          "ui/form/textarea"
+          changeset=this.changeset
+          isWide=CQ.features.wide
+          onUpdate=this.updateChangeset
+        )
+      )
+    }}
+  </ContainerQuery>
+
+  <div local-class="actions">
+    <button
+      data-test-button="Submit"
+      local-class="submit-button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.ts
@@ -1,0 +1,35 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface UiFormSignature {
+  Args: {};
+  Element: HTMLFormElement;
+}
+
+export default class UiFormComponent extends Component<UiFormSignature> {
+  formId = guidFor(this);
+
+  @tracked changeset = this.args.data ?? ({} as Record<string, any>);
+
+  @action submitForm(event: SubmitEvent): void {
+    event.preventDefault();
+
+    console.table(this.changeset);
+  }
+
+  @action updateChangeset({ key, value }: { key: string; value: any }): void {
+    this.changeset = {
+      ...this.changeset,
+      [key]: value,
+    };
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form': typeof UiFormComponent;
+    'ui/form': typeof UiFormComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.hbs
@@ -1,0 +1,45 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isInline={{@isInline}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label id={{concat l.inputId "-label"}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <span
+      aria-checked={{if this.isChecked "true" "false"}}
+      aria-disabled={{if @isDisabled "true" "false"}}
+      aria-labelledby={{concat f.inputId "-label"}}
+      aria-readonly={{if @isReadOnly "true" "false"}}
+      aria-required={{if @isRequired "true" "false"}}
+      local-class="checkbox
+        {{if this.isChecked 'is-checked'}}
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      data-test-field={{@label}}
+      role="checkbox"
+      tabindex={{unless @isDisabled "0"}}
+      {{on "click" this.updateValue}}
+      {{on "keypress" this.updateValueByPressingSpace}}
+    >
+      {{#if this.isChecked}}
+        {{svg-jar
+          "check"
+          class=(local-class "checkmark-icon")
+          desc="A checkmark to indicate that the input field is checked"
+          role="img"
+        }}
+      {{/if}}
+    </span>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
@@ -1,0 +1,50 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormCheckboxSignature {
+  Args: {};
+}
+
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
+  get errorMessage(): string | undefined {
+    if (!this.args.isRequired) {
+      return undefined;
+    }
+
+    if (!this.isChecked) {
+      return 'Please select the checkbox.';
+    }
+
+    return undefined;
+  }
+
+  get isChecked(): boolean {
+    return (get(this.args.changeset, this.args.key) as boolean) ?? false;
+  }
+
+  @action updateValue(): void {
+    if (this.args.isDisabled || this.args.isReadOnly) {
+      return;
+    }
+
+    const value = !this.isChecked;
+
+    this.args.onUpdate({
+      key: this.args.key,
+      value,
+    });
+  }
+
+  @action updateValueByPressingSpace(event: KeyboardEvent): void {
+    if (event.code === 'Space' || event.key === 'Space') {
+      this.updateValue();
+    }
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Checkbox': typeof UiFormCheckboxComponent;
+    'ui/form/checkbox': typeof UiFormCheckboxComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/field.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/field.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-field-container
+  local-class="container
+    {{if @isInline 'is-inline'}}
+    {{if @isWide 'is-wide'}}
+    {{unless @errorMessage 'no-feedback'}}
+  "
+>
+  <div local-class="label">
+    {{yield (hash inputId=this.inputId) to="label"}}
+  </div>
+
+  <div local-class="field">
+    {{yield (hash inputId=this.inputId) to="field"}}
+  </div>
+
+  {{#if @errorMessage}}
+    <div local-class="feedback is-error">dback" "is-error"}}
+    >
+      {{svg-jar
+        "alert"
+        desc="A warning to indicate that the input field has an error"
+        role="img"
+      }}
+
+      <span
+        data-test-feedback
+        local-class="message"
+        role="alert"
+      >
+        {{@errorMessage}}
+      </span>
+    </div>
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/field.ts
@@ -1,0 +1,17 @@
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+
+interface UiFormFieldSignature {
+  Args: {};
+}
+
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
+  inputId = guidFor(this);
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Field': typeof UiFormFieldComponent;
+    'ui/form/field': typeof UiFormFieldComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <input
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="input
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      type={{this.type}}
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    />
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
@@ -1,0 +1,46 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormInputSignature {
+  Args: {};
+}
+
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get type(): string {
+    return this.args.type ?? 'text';
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Input': typeof UiFormInputComponent;
+    'ui/form/input': typeof UiFormInputComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.hbs
@@ -1,0 +1,33 @@
+<Ui::Form::Field
+  @errorMessage={{this.errorMessage}}
+  @isWide={{@isWide}}
+>
+  <:label as |l|>
+    <label data-test-label for={{l.inputId}}>
+      {{@label}}
+
+      {{#if @isRequired}}
+        <span aria-hidden="true">
+          *
+        </span>
+      {{/if}}
+    </label>
+  </:label>
+
+  <:field as |f|>
+    <textarea
+      data-test-field={{@label}}
+      disabled={{@isDisabled}}
+      id={{f.inputId}}
+      local-class="textarea
+        {{if (strict-or @isDisabled @isReadOnly) 'is-disabled'}}
+      "
+      placeholder={{@placeholder}}
+      readonly={{@isReadOnly}}
+      required={{@isRequired}}
+      rows="4"
+      value={{this.value}}
+      {{on "input" this.updateValue}}
+    ></textarea>
+  </:field>
+</Ui::Form::Field>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.ts
@@ -1,0 +1,42 @@
+import { action, get } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface UiFormTextareaSignature {
+  Args: {};
+}
+
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
+  get errorMessage(): string | undefined {
+    const { isRequired } = this.args;
+
+    if (!isRequired) {
+      return undefined;
+    }
+
+    if (!this.value) {
+      return 'Please provide a value.';
+    }
+
+    return undefined;
+  }
+
+  get value(): string {
+    const { changeset, key } = this.args;
+
+    return ((get(changeset, key) as string) ?? '').toString();
+  }
+
+  @action updateValue(event: Event): void {
+    const { key, onUpdate } = this.args;
+    const { value } = event.target as HTMLInputElement;
+
+    onUpdate({ key, value });
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Form::Textarea': typeof UiFormTextareaComponent;
+    'ui/form/textarea': typeof UiFormTextareaComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/page.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/page.hbs
@@ -1,0 +1,14 @@
+<div local-class="container">
+  <h1 local-class="header">
+    {{@title}}
+  </h1>
+
+  <div
+    id="main-content"
+    local-class="body"
+    tabindex="-1"
+    ...attributes
+  >
+    {{yield}}
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/page.ts
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+
+interface UiPageSignature {
+  Args: {};
+  Element: HTMLDivElement;
+}
+
+export default class UiPageComponent extends Component<UiPageSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Ui::Page': typeof UiPageComponent;
+    'ui/page': typeof UiPageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-1.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-1.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    tall=(aspectRatio max=0.8)
+    square=(aspectRatio min=0.8 max=1.25)
+    wide=(aspectRatio min=1.25)
+  }}
+  @tagName="section"
+  local-class="container"
+  ...attributes
+>
+  <header>
+    <h2>Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <WidgetsWidget1Item @title="Item 1" />
+    </div>
+
+    <div local-class="item-2">
+      <WidgetsWidget1Item @title="Item 2" />
+    </div>
+
+    <div local-class="item-3">
+      <WidgetsWidget1Item @title="Item 3" />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-1.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-1.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget1Signature {
+  Args: {};
+  Element: HTMLElement;
+}
+
+const WidgetsWidget1Component = templateOnlyComponent<WidgetsWidget1Signature>();
+
+export default WidgetsWidget1Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget1': typeof WidgetsWidget1Component;
+    'widgets/widget-1': typeof WidgetsWidget1Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2.hbs
@@ -1,0 +1,26 @@
+<ContainerQuery
+  @features={{hash
+    short=(height max=240)
+    tall=(height min=240 max=480)
+    very-tall=(height min=480)
+  }}
+  @tagName="section"
+  local-class="container"
+  as |CQ|
+>
+  <header>
+    <h2>Widget 2</h2>
+  </header>
+
+  {{#unless CQ.features.short}}
+    <div data-test-visualization local-class="visualization">
+      <Widgets::Widget-2::StackedChart @data={{this.data}} />
+    </div>
+  {{/unless}}
+
+  <div data-test-captions local-class="captions">
+    <Widgets::Widget-2::Captions
+      @summaries={{this.summaries}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2.ts
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
+import {
+  createDataForVisualization,
+  createSummariesForCaptions,
+} from '../../utils/components/widgets/widget-2';
+
+interface WidgetsWidget2Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
+  @tracked data = [] as Data[];
+  @tracked summaries = [] as Summary[];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.data = createDataForVisualization(musicRevenue);
+    this.summaries = createSummariesForCaptions(this.data);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2': typeof WidgetsWidget2Component;
+    'widgets/widget-2': typeof WidgetsWidget2Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/captions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/captions.hbs
@@ -1,0 +1,114 @@
+<ContainerQuery
+  @features={{hash large=(width min=320) tall=(height min=80)}}
+  as |CQ|
+>
+  <div
+    local-class="container {{unless CQ.features.tall 'flat'}}"
+  >
+    {{#if this.summary}}
+      <div
+        local-class="summary {{if
+          CQ.features.large
+          'horizontal-layout'
+        }}"
+        tabindex="0"
+      >
+        <h3
+          local-class="music-format {{unless
+            CQ.features.large
+            'small-font-size'
+          }}"
+        >
+          <span
+            local-class="marker"
+            {{this.colorSvg this.summary.markerColor}}
+          >
+            {{svg-jar
+              "stop"
+              desc="A square whose color matches that of a bar in the bar chart"
+              role="img"
+            }}
+          </span>
+
+          <span data-test-field="Music Format">
+            {{this.summary.musicFormat}}
+          </span>
+        </h3>
+
+        <div
+          data-test-field="Annual Revenue"
+          local-class="annual-revenue"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Annual revenue:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.averageRevenue}}
+          </span>
+        </div>
+
+        <div
+          data-test-field="Relevant Years"
+          local-class="relevant-years"
+        >
+          {{#if (strict-or CQ.features.tall CQ.features.large)}}
+            <span>Relevant years:</span>
+          {{/if}}
+
+          <span local-class="highlight">
+            {{this.summary.relevantYears.min}}
+            -
+            {{this.summary.relevantYears.max}}
+          </span>
+        </div>
+      </div>
+
+      {{#if this.canShowPreviousButton}}
+        <button
+          aria-label="Previous"
+          data-test-button="Previous"
+          local-class="previous-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary -1)}}
+        >
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            {{svg-jar
+              "chevron-left"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing left"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+
+      {{#if this.canShowNextButton}}
+        <button
+          aria-label="Next"
+          data-test-button="Next"
+          local-class="next-button"
+          type="button"
+          {{on "click" (fn this.showNextSummary 1)}}
+        >
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            {{svg-jar
+              "chevron-right"
+              class=(local-class "icon")
+              desc="A chevron arrow pointing right"
+              role="img"
+            }}
+
+          {{/if}}
+        </button>
+      {{/if}}
+    {{/if}}
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/captions.ts
@@ -1,0 +1,58 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
+
+const colorSvg = modifier((container: Element, [color]: [string]) => {
+  const svgElement = container.querySelector('svg');
+
+  if (!svgElement) {
+    return;
+  }
+
+  svgElement.style.setProperty('color', color);
+});
+
+interface WidgetsWidget2CaptionsSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
+  colorSvg = colorSvg;
+
+  @tracked currentIndex = 0;
+
+  get canShowNextButton(): boolean {
+    return this.currentIndex < this.summaries.length - 1;
+  }
+
+  get canShowPreviousButton(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  get summaries(): Summary[] {
+    return this.args.summaries ?? [];
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
+  }
+
+  @action showNextSummary(increment = 1): void {
+    const { currentIndex, summaries } = this;
+
+    const numSummaries = summaries.length;
+    const nextIndex = (currentIndex + increment + numSummaries) % numSummaries;
+
+    this.currentIndex = nextIndex;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::Captions': typeof WidgetsWidget2CaptionsComponent;
+    'widgets/widget-2/captions': typeof WidgetsWidget2CaptionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,0 +1,7 @@
+<div
+  local-class="svg-container"
+  {{draw-stacked-chart data=@data}}
+>
+  <svg local-class="svg">
+  </svg>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget2StackedChartSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget2::StackedChart': typeof WidgetsWidget2StackedChartComponent;
+    'widgets/widget-2/stacked-chart': typeof WidgetsWidget2StackedChartComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3.hbs
@@ -1,0 +1,17 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 3</h2>
+
+    <div local-class="actions">
+      <a data-test-link="All tours" href="#">
+        All tours
+      </a>
+    </div>
+  </header>
+
+  <div data-test-tour-schedule local-class="tour-schedule">
+    <Widgets::Widget-3::TourSchedule
+      @concert={{this.concertData}}
+    />
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3.ts
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
+
+interface WidgetsWidget3Signature {
+  Args: {};
+}
+
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
+  @tracked concertData = {} as Concert;
+
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
+    super(owner, args);
+
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.concertData = concertData;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3': typeof WidgetsWidget3Component;
+    'widgets/widget-3': typeof WidgetsWidget3Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -1,0 +1,14 @@
+<div
+  local-class="image-container"
+  {{containerQuery debounce=300 onQuery=this.setImageSource}}
+>
+  {{#if this.imageSource}}
+    <img
+      alt=""
+      data-test-image="Concert"
+      local-class="image"
+      role="presentation"
+      src={{this.imageSource}}
+    />
+  {{/if}}
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { containerQuery, type Dimensions } from 'ember-container-query';
+
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
+  Args: {};
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+    'widgets/widget-3/tour-schedule/responsive-image': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4.hbs
@@ -1,0 +1,15 @@
+<section local-class="container">
+  <header local-class="header">
+    <h2>Widget 4</h2>
+  </header>
+
+  <div local-class="memo-highlight">
+    <Widgets::Widget-4::Memo />
+  </div>
+
+  <div local-class="actions">
+    <a data-test-link="All memos" href="#">
+      All memos
+    </a>
+  </div>
+</section>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4Signature {
+  Args: {};
+}
+
+const WidgetsWidget4Component = templateOnlyComponent<WidgetsWidget4Signature>();
+
+export default WidgetsWidget4Component;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4': typeof WidgetsWidget4Component;
+    'widgets/widget-4': typeof WidgetsWidget4Component;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo.hbs
@@ -1,0 +1,28 @@
+<ContainerQuery
+  @features={{hash
+    small=(width max=200)
+    large=(width min=200)
+    short=(height max=200)
+  }}
+  @tagName="article"
+  local-class="container"
+  as |CQ|
+>
+  <div local-class="header-container">
+    <WidgetsWidget4MemoHeader
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="body-container">
+    <WidgetsWidget4MemoBody
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+
+  <div local-class="actions-container">
+    <WidgetsWidget4MemoActions
+      @cqFeatures={{CQ.features}}
+    />
+  </div>
+</ContainerQuery>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoComponent = templateOnlyComponent<WidgetsWidget4MemoSignature>();
+
+export default WidgetsWidget4MemoComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo': typeof WidgetsWidget4MemoComponent;
+    'widgets/widget-4/memo': typeof WidgetsWidget4MemoComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.hbs
@@ -1,0 +1,59 @@
+<div
+  data-test-memo-actions
+  local-class="actions {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <button
+    aria-label="Comment"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "message-processing-outline"
+      class=(local-class "icon icon-comment")
+      desc="A speech bubble"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Repost"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "sync"
+      class=(local-class "icon icon-repost")
+      desc="Two circular arrows pointing to each other"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Like"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "heart-outline"
+      class=(local-class "icon")
+      desc="A heart"
+      role="img"
+    }}
+  </button>
+
+  <button
+    aria-label="Share"
+    local-class="button"
+    type="button"
+  >
+    {{svg-jar
+      "share-variant-outline"
+      class=(local-class "icon")
+      desc="A circular node that branches out to two circular nodes"
+      role="img"
+    }}
+  </button>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface WidgetsWidget4MemoActionsSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
+
+export default WidgetsWidget4MemoActionsComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Actions': typeof WidgetsWidget4MemoActionsComponent;
+    'widgets/widget-4/memo/actions': typeof WidgetsWidget4MemoActionsComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.hbs
@@ -1,0 +1,35 @@
+<div
+  data-test-memo-body
+  local-class="body {{if
+    (strict-or @cqFeatures.small @cqFeatures.short)
+    'minimal-layout'
+  }}"
+>
+  <div local-class="message" tabindex="0">
+    <p>
+      <strong>Buffon’s needle</strong>
+      is a classic Monte Carlo simulation that we can conduct in
+      a classroom.
+    </p>
+    <p>
+      We give the students, say 10 needles each, and have them
+      drop the needles on a paper that we provide also.
+    </p>
+    <p>
+      The paper is special, in that it has parallel lines that
+      are separated by the length of a needle.
+    </p>
+    <p>
+      Each student records how many needles intersect one of the
+      lines, then we tally their numbers to arrive at a very
+      special number. (Guess
+      <a
+        href="https://crunchingnumbers.live/2016/02/01/monte-carlo-simulations-buffons-needle/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        who
+      </a>?)
+    </p>
+  </div>
+</div>

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget4MemoBodySignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}
+
+export default WidgetsWidget4MemoBodyComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Body': typeof WidgetsWidget4MemoBodyComponent;
+    'widgets/widget-4/memo/body': typeof WidgetsWidget4MemoBodyComponent;
+  }
+}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.hbs
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.hbs
@@ -1,0 +1,35 @@
+{{#let
+  (strict-and @cqFeatures.large @cqFeatures.short)
+  (strict-or @cqFeatures.small @cqFeatures.short)
+  as |showHorizontalLayout showMinimalLayout|
+}}
+  <div
+    data-test-memo-header
+    local-class="
+      header
+      {{if showMinimalLayout 'minimal-layout'}}
+      {{if showHorizontalLayout 'horizontal-layout'}}
+    "
+  >
+    {{#unless showMinimalLayout}}
+      <div local-class="avatar-container">
+        <img
+          alt=""
+          data-test-image="Avatar"
+          local-class="avatar"
+          role="presentation"
+          src="/images/widgets/widget-4/avatar.jpg"
+        />
+      </div>
+    {{/unless}}
+
+    <p local-class="name">
+      Isaac Lee
+    </p>
+
+    <div local-class="metadata">
+      <a href="#" local-class="handle">@ijlee2</a>
+      · 38m
+    </div>
+  </div>
+{{/let}}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+interface WidgetsWidget4MemoHeaderSignature {
+  Args: {};
+}
+
+const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}
+
+export default WidgetsWidget4MemoHeaderComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget4::Memo::Header': typeof WidgetsWidget4MemoHeaderComponent;
+    'widgets/widget-4/memo/header': typeof WidgetsWidget4MemoHeaderComponent;
+  }
+}

--- a/tests/helpers/shared-test-setups/ember-container-query-glint.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-glint.ts
@@ -73,7 +73,7 @@ const context: Context = {
       {
         Args: undefined,
         Blocks: undefined,
-        Element: undefined,
+        Element: ['HTMLElement'],
       },
     ],
     [

--- a/tests/helpers/shared-test-setups/ember-container-query-nested.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-nested.ts
@@ -73,7 +73,7 @@ const context: Context = {
       {
         Args: undefined,
         Blocks: undefined,
-        Element: undefined,
+        Element: ['HTMLElement'],
       },
     ],
     [

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -73,7 +73,7 @@ const context: Context = {
       {
         Args: undefined,
         Blocks: undefined,
-        Element: undefined,
+        Element: ['HTMLElement'],
       },
     ],
     [

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -73,7 +73,7 @@ const context: Context = {
       {
         Args: undefined,
         Blocks: undefined,
-        Element: undefined,
+        Element: ['HTMLElement'],
       },
     ],
     [

--- a/tests/helpers/shared-test-setups/has-declaration-file.ts
+++ b/tests/helpers/shared-test-setups/has-declaration-file.ts
@@ -21,7 +21,7 @@ const context: Context = {
       {
         Args: undefined,
         Blocks: undefined,
-        Element: undefined,
+        Element: ['HTMLElement'],
       },
     ],
     [

--- a/tests/helpers/shared-test-setups/has-no-args.ts
+++ b/tests/helpers/shared-test-setups/has-no-args.ts
@@ -68,7 +68,7 @@ const context: Context = {
       {
         Args: undefined,
         Blocks: undefined,
-        Element: undefined,
+        Element: ['HTMLElement'],
       },
     ],
     [

--- a/tests/steps/update-signatures/has-backing-class.test.ts
+++ b/tests/steps/update-signatures/has-backing-class.test.ts
@@ -1,0 +1,29 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { updateSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  context,
+  options,
+} from '../../helpers/shared-test-setups/has-backing-class.js';
+
+test('steps | update-signatures > has-backing-class', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/update-signatures/has-backing-class/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/update-signatures/has-backing-class/output',
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  updateSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/update-signatures/has-declaration-file.test.ts
+++ b/tests/steps/update-signatures/has-declaration-file.test.ts
@@ -1,0 +1,29 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { updateSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  context,
+  options,
+} from '../../helpers/shared-test-setups/has-declaration-file.js';
+
+test('steps | update-signatures > has-declaration-file', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/update-signatures/has-declaration-file/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/update-signatures/has-declaration-file/output',
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  updateSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/update-signatures/has-hbs-file-only.test.ts
+++ b/tests/steps/update-signatures/has-hbs-file-only.test.ts
@@ -1,0 +1,29 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { updateSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  context,
+  options,
+} from '../../helpers/shared-test-setups/has-hbs-file-only.js';
+
+test('steps | update-signatures > has-hbs-file-only', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/update-signatures/has-hbs-file-only/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/update-signatures/has-hbs-file-only/output',
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  updateSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/steps/update-signatures/has-no-args.test.ts
+++ b/tests/steps/update-signatures/has-no-args.test.ts
@@ -1,0 +1,29 @@
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '@codemod-utils/tests';
+
+import { updateSignatures } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  context,
+  options,
+} from '../../helpers/shared-test-setups/has-no-args.js';
+
+test('steps | update-signatures > has-no-args', function () {
+  const inputProject = convertFixtureToJson(
+    'steps/update-signatures/has-no-args/input',
+  );
+
+  const outputProject = convertFixtureToJson(
+    'steps/update-signatures/has-no-args/output',
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  updateSignatures(context, options);
+
+  assertFixture(outputProject, codemodOptions);
+});


### PR DESCRIPTION
## Description

A continuation of #20.

The pull request uses the `Element` node to illustrate how, given `context.signature`, we can find and update the component's `Signature` in the `update-signature` step.
