### PR TITLE
Defined findBlocks

### DIFF
--- a/src/steps/analyze-project/analyze-components.ts
+++ b/src/steps/analyze-project/analyze-components.ts
@@ -25,7 +25,7 @@ export function analyzeComponents(
       : undefined;
 
     const Args = findArguments(options);
-    const Blocks = findBlocks(options);
+    const Blocks = findBlocks(templateFile);
     const Element = findElement(templateFile);
 
     signatureMap.set(entityName, {

--- a/src/steps/analyze-project/find-blocks.ts
+++ b/src/steps/analyze-project/find-blocks.ts
@@ -1,8 +1,49 @@
-import type { Options } from '../../types/index.js';
+import { AST } from '@codemod-utils/ast-template';
 
-// @ts-expect-error: Method to be implemented
-export function findBlocks(options: Options): Set<string> | undefined {
-  // ...
+import type { Signature } from '../../types/index.js';
+import {
+  getBlockParameterType,
+  normalizeBlockName,
+} from '../../utils/components.js';
 
-  return undefined;
+export function findBlocks(file: string | undefined): Signature['Blocks'] {
+  if (file === undefined) {
+    return;
+  }
+
+  const traverse = AST.traverse();
+
+  const blocksMap = new Map<string, string[]>();
+
+  traverse(file, {
+    MustacheStatement(node) {
+      if (
+        node.path.type !== 'PathExpression' ||
+        node.path.original !== 'yield'
+      ) {
+        return;
+      }
+
+      const toArgument = node.hash.pairs.find(({ key }) => {
+        return key === 'to';
+      });
+
+      // @ts-ignore: Assume that types from external packages are correct
+      const blockName = normalizeBlockName(toArgument?.value.original);
+
+      const positionalArgumentTypes = node.params.map(
+        ({ type: recastType }) => {
+          return getBlockParameterType(recastType);
+        },
+      );
+
+      blocksMap.set(blockName, positionalArgumentTypes);
+    },
+  });
+
+  if (blocksMap.size === 0) {
+    return;
+  }
+
+  return new Map(Array.from(blocksMap).sort());
 }

--- a/src/steps/analyze-project/find-element.ts
+++ b/src/steps/analyze-project/find-element.ts
@@ -1,15 +1,16 @@
 import { AST } from '@codemod-utils/ast-template';
 
+import type { Signature } from '../../types/index.js';
 import { getHtmlInterface } from '../../utils/components.js';
 
-export function findElement(file: string | undefined): string[] | undefined {
+export function findElement(file: string | undefined): Signature['Element'] {
   if (file === undefined) {
     return;
   }
 
   const traverse = AST.traverse();
 
-  const elementTags: string[] = [];
+  const htmlInterfaces = new Set<string>();
 
   traverse(file, {
     ElementNode(node) {
@@ -21,15 +22,13 @@ export function findElement(file: string | undefined): string[] | undefined {
         return;
       }
 
-      elementTags.push(node.tag);
+      htmlInterfaces.add(getHtmlInterface(node.tag));
     },
   });
 
-  if (elementTags.length === 0) {
+  if (htmlInterfaces.size === 0) {
     return;
   }
 
-  const htmlInterfaces = elementTags.map(getHtmlInterface);
-
-  return Array.from(new Set(htmlInterfaces)).sort();
+  return Array.from(htmlInterfaces).sort();
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ type ExtensionMap = Map<string, Set<string>>;
 
 type Signature = {
   Args: Set<string> | undefined;
-  Blocks: Set<string> | undefined;
+  Blocks: Map<string, string[]> | undefined;
   Element: string[] | undefined;
 };
 

--- a/src/utils/components.ts
+++ b/src/utils/components.ts
@@ -1,4 +1,6 @@
 export * from './components/get-base-component.js';
+export * from './components/get-block-parameter.type.js';
 export * from './components/get-component-file-path.js';
 export * from './components/get-html-interface.js';
+export * from './components/normalize-block-name.js';
 export * from './components/transform-entity-name.js';

--- a/src/utils/components/get-block-parameter.type.ts
+++ b/src/utils/components/get-block-parameter.type.ts
@@ -1,0 +1,17 @@
+const defaultTsType = 'unknown';
+
+const mapping = new Map<string, string>([
+  ['BooleanLiteral', 'boolean'],
+  ['NullLiteral', 'null'],
+  ['NumberLiteral', 'number'],
+  ['PathExpression', 'unknown'],
+  ['StringLiteral', 'string'],
+  ['SubExpression', 'unknown'],
+  ['UndefinedLiteral', 'undefined'],
+]);
+
+export function getBlockParameterType(recastType: string): string {
+  const tsType = mapping.get(recastType);
+
+  return tsType ?? defaultTsType;
+}

--- a/src/utils/components/normalize-block-name.ts
+++ b/src/utils/components/normalize-block-name.ts
@@ -1,0 +1,16 @@
+export function normalizeBlockName(blockName: string | undefined): string {
+  switch (blockName) {
+    case undefined: {
+      return 'default';
+    }
+
+    case 'else':
+    case 'inverse': {
+      return 'else';
+    }
+
+    default: {
+      return blockName;
+    }
+  }
+}

--- a/tests/helpers/shared-test-setups/ember-container-query-addon.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-addon.ts
@@ -96,7 +96,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: undefined,
       },
     ],
@@ -112,7 +112,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -144,7 +147,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: undefined,
       },
     ],

--- a/tests/helpers/shared-test-setups/ember-container-query-glint.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-glint.ts
@@ -96,7 +96,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],
@@ -112,7 +112,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -144,7 +147,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
     ],

--- a/tests/helpers/shared-test-setups/ember-container-query-nested.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-nested.ts
@@ -96,7 +96,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],
@@ -112,7 +112,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -144,7 +147,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
     ],

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -96,7 +96,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],
@@ -112,7 +112,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -144,7 +147,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
     ],

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -96,7 +96,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],
@@ -112,7 +112,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -144,7 +147,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
     ],

--- a/tests/helpers/shared-test-setups/has-backing-class.ts
+++ b/tests/helpers/shared-test-setups/has-backing-class.ts
@@ -74,7 +74,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],
@@ -90,7 +90,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -114,7 +117,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
     ],

--- a/tests/helpers/shared-test-setups/has-no-args.ts
+++ b/tests/helpers/shared-test-setups/has-no-args.ts
@@ -83,7 +83,7 @@ const context: Context = {
       'ui/form',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],
@@ -99,7 +99,10 @@ const context: Context = {
       'ui/form/field',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([
+          ['field', ['unknown']],
+          ['label', ['unknown']],
+        ]),
         Element: undefined,
       },
     ],
@@ -123,7 +126,7 @@ const context: Context = {
       'ui/page',
       {
         Args: undefined,
-        Blocks: undefined,
+        Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
     ],

--- a/tests/utils/components/get-block-parameter-type/base-case.test.ts
+++ b/tests/utils/components/get-block-parameter-type/base-case.test.ts
@@ -1,0 +1,13 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { getBlockParameterType } from '../../../../src/utils/components.js';
+
+test('utils | components | get-block-parameter-type > base case', function () {
+  assert.strictEqual(getBlockParameterType('BooleanLiteral'), 'boolean');
+  assert.strictEqual(getBlockParameterType('NullLiteral'), 'null');
+  assert.strictEqual(getBlockParameterType('NumberLiteral'), 'number');
+  assert.strictEqual(getBlockParameterType('PathExpression'), 'unknown');
+  assert.strictEqual(getBlockParameterType('StringLiteral'), 'string');
+  assert.strictEqual(getBlockParameterType('SubExpression'), 'unknown');
+  assert.strictEqual(getBlockParameterType('UndefinedLiteral'), 'undefined');
+});

--- a/tests/utils/components/get-block-parameter-type/edge-case-recast-type-is-unknown.test.ts
+++ b/tests/utils/components/get-block-parameter-type/edge-case-recast-type-is-unknown.test.ts
@@ -1,0 +1,7 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { getBlockParameterType } from '../../../../src/utils/components.js';
+
+test('utils | components | get-block-parameter-type > edge case (recast type is unknown)', function () {
+  assert.strictEqual(getBlockParameterType('BrandNewType'), 'unknown');
+});

--- a/tests/utils/components/normalize-block-name/base-case.test.ts
+++ b/tests/utils/components/normalize-block-name/base-case.test.ts
@@ -1,0 +1,9 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { normalizeBlockName } from '../../../../src/utils/components.js';
+
+test('utils | components | normalize-block-name > base case', function () {
+  assert.strictEqual(normalizeBlockName('default'), 'default');
+  assert.strictEqual(normalizeBlockName('header'), 'header');
+  assert.strictEqual(normalizeBlockName('footer'), 'footer');
+});

--- a/tests/utils/components/normalize-block-name/edge-case-block-name-is-undefined.test.ts
+++ b/tests/utils/components/normalize-block-name/edge-case-block-name-is-undefined.test.ts
@@ -1,0 +1,7 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { normalizeBlockName } from '../../../../src/utils/components.js';
+
+test('utils | components | normalize-block-name > edge case (block name is undefined)', function () {
+  assert.strictEqual(normalizeBlockName(undefined), 'default');
+});

--- a/tests/utils/components/normalize-block-name/edge-case-else-block.test.ts
+++ b/tests/utils/components/normalize-block-name/edge-case-else-block.test.ts
@@ -1,0 +1,8 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { normalizeBlockName } from '../../../../src/utils/components.js';
+
+test('utils | components | normalize-block-name > edge case (else block)', function () {
+  assert.strictEqual(normalizeBlockName('else'), 'else');
+  assert.strictEqual(normalizeBlockName('inverse'), 'else');
+});


### PR DESCRIPTION
## Description

I updated the `analyze-project` step so that the codemod knows:

- If `{{yield}}`'s (named blocks) exist
- How many positional arguments a block has
- For positional arguments whose value is static (note, this is seldom the case), their type

In a separate pull request, I will update the codemod to fill out `Signature['Blocks']`.