### PR TITLE
Simplified blueprints

### DIFF
--- a/src/blueprints/ember-cli/template-only-component.ts
+++ b/src/blueprints/ember-cli/template-only-component.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface <%= entity.classifiedName %>Signature {
-  Args: {};
-}
+interface <%= entity.classifiedName %>Signature {}
 
 const <%= entity.classifiedName %>Component =
   templateOnlyComponent<<%= entity.classifiedName %>Signature>();
 
 export default <%= entity.classifiedName %>Component;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    '<%= entity.doubleColonizedName %>': typeof <%= entity.classifiedName %>Component;
-    '<%= entity.name %>': typeof <%= entity.classifiedName %>Component;
-  }
-}

--- a/src/steps/create-registries.ts
+++ b/src/steps/create-registries.ts
@@ -23,13 +23,7 @@ export function createRegistries(context: Context, options: Options): void {
 
   const fileMap = new Map<FilePath, FileContent>();
 
-  for (const [entityName, extensions] of context.extensionMap) {
-    const hasBackingClass = extensions.has('.ts');
-
-    if (!hasBackingClass) {
-      continue;
-    }
-
+  for (const [entityName] of context.extensionMap) {
     const filePath = getComponentFilePath(options)(entityName);
 
     const data = {

--- a/src/steps/create-signatures.ts
+++ b/src/steps/create-signatures.ts
@@ -19,13 +19,7 @@ export function createSignatures(context: Context, options: Options): void {
 
   const fileMap = new Map<FilePath, FileContent>();
 
-  for (const [entityName, extensions] of context.extensionMap) {
-    const hasBackingClass = extensions.has('.ts');
-
-    if (!hasBackingClass) {
-      continue;
-    }
-
+  for (const [entityName] of context.extensionMap) {
     const filePath = getComponentFilePath(options)(entityName);
 
     const data = {

--- a/tests/fixtures/steps/create-registries/has-declaration-file/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-registries/has-declaration-file/input/app/components/tracks.ts
@@ -8,10 +8,3 @@ const TracksComponent =
   templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Tracks': typeof TracksComponent;
-    'tracks': typeof TracksComponent;
-  }
-}

--- a/tests/fixtures/steps/create-registries/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/create-registries/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
@@ -8,10 +8,3 @@ const WidgetsWidget3TourScheduleComponent =
   templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
 
 export default WidgetsWidget3TourScheduleComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
-    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
-  }
-}

--- a/tests/fixtures/steps/create-registries/has-hbs-file-only/input/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/create-registries/has-hbs-file-only/input/app/components/ui/form/information.ts
@@ -8,10 +8,3 @@ const UiFormInformationComponent =
   templateOnlyComponent<UiFormInformationSignature>();
 
 export default UiFormInformationComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Ui::Form::Information': typeof UiFormInformationComponent;
-    'ui/form/information': typeof UiFormInformationComponent;
-  }
-}

--- a/tests/fixtures/steps/create-registries/has-hbs-file-only/input/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/create-registries/has-hbs-file-only/input/app/components/widgets/widget-5.ts
@@ -8,10 +8,3 @@ const WidgetsWidget5Component =
   templateOnlyComponent<WidgetsWidget5Signature>();
 
 export default WidgetsWidget5Component;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget5': typeof WidgetsWidget5Component;
-    'widgets/widget-5': typeof WidgetsWidget5Component;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/tracks.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface TracksSignature {
-  Args: {};
-}
+interface TracksSignature {}
 
 const TracksComponent =
   templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Tracks': typeof TracksComponent;
-    'tracks': typeof TracksComponent;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/input/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
-}
+interface WidgetsWidget3TourScheduleSignature {}
 
 const WidgetsWidget3TourScheduleComponent =
   templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
 
 export default WidgetsWidget3TourScheduleComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
-    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/tracks.ts
@@ -8,10 +8,3 @@ const TracksComponent =
   templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Tracks': typeof TracksComponent;
-    'tracks': typeof TracksComponent;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/create-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -8,10 +8,3 @@ const WidgetsWidget3TourScheduleComponent =
   templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
 
 export default WidgetsWidget3TourScheduleComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
-    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/ui/form/information.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface UiFormInformationSignature {
-  Args: {};
-}
+interface UiFormInformationSignature {}
 
 const UiFormInformationComponent =
   templateOnlyComponent<UiFormInformationSignature>();
 
 export default UiFormInformationComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Ui::Form::Information': typeof UiFormInformationComponent;
-    'ui/form/information': typeof UiFormInformationComponent;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/input/app/components/widgets/widget-5.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget5Signature {
-  Args: {};
-}
+interface WidgetsWidget5Signature {}
 
 const WidgetsWidget5Component =
   templateOnlyComponent<WidgetsWidget5Signature>();
 
 export default WidgetsWidget5Component;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget5': typeof WidgetsWidget5Component;
-    'widgets/widget-5': typeof WidgetsWidget5Component;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
@@ -8,10 +8,3 @@ const UiFormInformationComponent =
   templateOnlyComponent<UiFormInformationSignature>();
 
 export default UiFormInformationComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Ui::Form::Information': typeof UiFormInformationComponent;
-    'ui/form/information': typeof UiFormInformationComponent;
-  }
-}

--- a/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/create-signatures/has-hbs-file-only/output/app/components/widgets/widget-5.ts
@@ -8,10 +8,3 @@ const WidgetsWidget5Component =
   templateOnlyComponent<WidgetsWidget5Signature>();
 
 export default WidgetsWidget5Component;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget5': typeof WidgetsWidget5Component;
-    'widgets/widget-5': typeof WidgetsWidget5Component;
-  }
-}

--- a/tests/fixtures/steps/create-template-only-components/has-declaration-file/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-declaration-file/output/app/components/tracks.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface TracksSignature {
-  Args: {};
-}
+interface TracksSignature {}
 
 const TracksComponent =
   templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Tracks': typeof TracksComponent;
-    'tracks': typeof TracksComponent;
-  }
-}

--- a/tests/fixtures/steps/create-template-only-components/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
-}
+interface WidgetsWidget3TourScheduleSignature {}
 
 const WidgetsWidget3TourScheduleComponent =
   templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
 
 export default WidgetsWidget3TourScheduleComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget3::TourSchedule': typeof WidgetsWidget3TourScheduleComponent;
-    'widgets/widget-3/tour-schedule': typeof WidgetsWidget3TourScheduleComponent;
-  }
-}

--- a/tests/fixtures/steps/create-template-only-components/has-hbs-file-only/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-hbs-file-only/output/app/components/ui/form/information.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface UiFormInformationSignature {
-  Args: {};
-}
+interface UiFormInformationSignature {}
 
 const UiFormInformationComponent =
   templateOnlyComponent<UiFormInformationSignature>();
 
 export default UiFormInformationComponent;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Ui::Form::Information': typeof UiFormInformationComponent;
-    'ui/form/information': typeof UiFormInformationComponent;
-  }
-}

--- a/tests/fixtures/steps/create-template-only-components/has-hbs-file-only/output/app/components/widgets/widget-5.ts
+++ b/tests/fixtures/steps/create-template-only-components/has-hbs-file-only/output/app/components/widgets/widget-5.ts
@@ -1,17 +1,8 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget5Signature {
-  Args: {};
-}
+interface WidgetsWidget5Signature {}
 
 const WidgetsWidget5Component =
   templateOnlyComponent<WidgetsWidget5Signature>();
 
 export default WidgetsWidget5Component;
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    'Widgets::Widget5': typeof WidgetsWidget5Component;
-    'widgets/widget-5': typeof WidgetsWidget5Component;
-  }
-}


### PR DESCRIPTION
## Description

By simplifying the blueprint file, we can better separate the concerns of the following steps:

- `create-template-only-components`
- `create-signatures` and `create-registries` together
