### PR TITLE
Fill out Signature['Args'] (Part 1)

### DIFF
--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -3,7 +3,7 @@ import { AST as ASTTemplate } from '@codemod-utils/ast-template';
 
 import type { Signature } from '../../../types/index.js';
 
-function analyzeTemplate(file: string) {
+function analyzeTemplate(file: string, args: Set<string>): void {
   const traverse = ASTTemplate.traverse();
 
   traverse(file, {
@@ -12,7 +12,10 @@ function analyzeTemplate(file: string) {
         return;
       }
 
-      console.log(`Argument name: ${node.original}`);
+      const argumentName = node.original.replace(/^@/, '');
+      const key = argumentName.split('.')[0]!;
+
+      args.add(key);
     },
   });
 }
@@ -28,11 +31,13 @@ export function findArguments({
     return;
   }
 
-  analyzeTemplate(templateFile);
+  const args = new Set<string>();
+
+  analyzeTemplate(templateFile, args);
 
   if (classFile !== undefined) {
-    // analyzeClass(classFile);
+    // analyzeClass(classFile, args);
   }
 
-  return undefined;
+  return Array.from(args).sort();
 }

--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -7,7 +7,13 @@ function analyzeTemplate(file: string) {
   const traverse = ASTTemplate.traverse();
 
   traverse(file, {
-    // ...
+    PathExpression(node) {
+      if (node.head.type !== 'AtHead') {
+        return;
+      }
+
+      console.log(`Argument name: ${node.original}`);
+    },
   });
 }
 

--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -1,7 +1,15 @@
 // import { AST as ASTJavaScript } from '@codemod-utils/ast-javascript';
-// import { AST as ASTTemplate } from '@codemod-utils/ast-template';
+import { AST as ASTTemplate } from '@codemod-utils/ast-template';
 
 import type { Signature } from '../../../types/index.js';
+
+function analyzeTemplate(file: string) {
+  const traverse = ASTTemplate.traverse();
+
+  traverse(file, {
+    // ...
+  });
+}
 
 export function findArguments({
   classFile,
@@ -14,13 +22,11 @@ export function findArguments({
     return;
   }
 
-  // ...
+  analyzeTemplate(templateFile);
 
-  if (classFile === undefined) {
-    return;
+  if (classFile !== undefined) {
+    // analyzeClass(classFile);
   }
-
-  // ...
 
   return undefined;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,7 @@ type Context = {
 type ExtensionMap = Map<string, Set<string>>;
 
 type Signature = {
-  Args: Map<string, string[]> | undefined;
+  Args: string[] | undefined;
   Blocks: Map<string, string[]> | undefined;
   Element: string[] | undefined;
 };

--- a/tests/fixtures/ember-container-query-addon/input/addon/components/ui/form/information.d.ts
+++ b/tests/fixtures/ember-container-query-addon/input/addon/components/ui/form/information.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  formId: string;
   instructions?: string;
   title?: string;
 }

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/information.d.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/information.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  formId: string;
   instructions?: string;
   title?: string;
 }

--- a/tests/fixtures/ember-container-query-nested/input/app/components/ui/form/information/index.d.ts
+++ b/tests/fixtures/ember-container-query-nested/input/app/components/ui/form/information/index.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  formId: string;
   instructions?: string;
   title?: string;
 }

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/information/index.d.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/information/index.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  formId: string;
   instructions?: string;
   title?: string;
 }

--- a/tests/fixtures/ember-container-query/input/app/components/ui/form/information.d.ts
+++ b/tests/fixtures/ember-container-query/input/app/components/ui/form/information.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  formId: string;
   instructions?: string;
   title?: string;
 }

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/information.d.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/information.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  formId: string;
   instructions?: string;
   title?: string;
 }

--- a/tests/helpers/shared-test-setups/ember-container-query-addon.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-addon.ts
@@ -47,7 +47,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -55,7 +55,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -63,7 +63,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -71,7 +71,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -87,7 +87,7 @@ const context: Context = {
     [
       'tracks/table',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: undefined,
       },
@@ -103,7 +103,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -111,7 +118,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -122,7 +129,7 @@ const context: Context = {
     [
       'ui/form/information',
       {
-        Args: undefined,
+        Args: ['formId', 'instructions', 'title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -130,7 +137,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -138,7 +152,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -146,7 +167,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: undefined,
       },
@@ -154,7 +175,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -162,7 +183,7 @@ const context: Context = {
     [
       'widgets/widget-1/item',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -170,7 +191,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -178,7 +199,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -186,7 +207,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -194,7 +215,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -202,7 +223,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule',
       {
-        Args: undefined,
+        Args: ['concert'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -210,7 +231,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -218,7 +239,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -226,7 +247,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -234,7 +255,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -242,7 +263,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -250,7 +271,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -258,7 +279,7 @@ const context: Context = {
     [
       'widgets/widget-5',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-glint.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-glint.ts
@@ -47,7 +47,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -55,7 +55,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -63,7 +63,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: ['HTMLDivElement', 'HTMLImageElement'],
       },
@@ -71,7 +71,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -87,7 +87,7 @@ const context: Context = {
     [
       'tracks/table',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLTableElement'],
       },
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -103,7 +103,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -111,7 +118,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -122,7 +129,7 @@ const context: Context = {
     [
       'ui/form/information',
       {
-        Args: undefined,
+        Args: ['formId', 'instructions', 'title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -130,7 +137,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -138,7 +152,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -146,7 +167,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
@@ -154,7 +175,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -162,7 +183,7 @@ const context: Context = {
     [
       'widgets/widget-1/item',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -170,7 +191,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -178,7 +199,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -186,7 +207,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -194,7 +215,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -202,7 +223,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule',
       {
-        Args: undefined,
+        Args: ['concert'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -210,7 +231,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -218,7 +239,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -226,7 +247,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -234,7 +255,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -242,7 +263,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -250,7 +271,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -258,7 +279,7 @@ const context: Context = {
     [
       'widgets/widget-5',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-nested.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-nested.ts
@@ -47,7 +47,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -55,7 +55,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -63,7 +63,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: ['HTMLDivElement', 'HTMLImageElement'],
       },
@@ -71,7 +71,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -87,7 +87,7 @@ const context: Context = {
     [
       'tracks/table',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLTableElement'],
       },
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -103,7 +103,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -111,7 +118,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -122,7 +129,7 @@ const context: Context = {
     [
       'ui/form/information',
       {
-        Args: undefined,
+        Args: ['formId', 'instructions', 'title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -130,7 +137,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -138,7 +152,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -146,7 +167,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
@@ -154,7 +175,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -162,7 +183,7 @@ const context: Context = {
     [
       'widgets/widget-1/item',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -170,7 +191,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -178,7 +199,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -186,7 +207,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -194,7 +215,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -202,7 +223,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule',
       {
-        Args: undefined,
+        Args: ['concert'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -210,7 +231,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -218,7 +239,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -226,7 +247,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -234,7 +255,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -242,7 +263,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -250,7 +271,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -258,7 +279,7 @@ const context: Context = {
     [
       'widgets/widget-5',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -47,7 +47,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -55,7 +55,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -63,7 +63,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: ['HTMLDivElement', 'HTMLImageElement'],
       },
@@ -71,7 +71,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -87,7 +87,7 @@ const context: Context = {
     [
       'tracks/table',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLTableElement'],
       },
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -103,7 +103,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -111,7 +118,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -122,7 +129,7 @@ const context: Context = {
     [
       'ui/form/information',
       {
-        Args: undefined,
+        Args: ['formId', 'instructions', 'title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -130,7 +137,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -138,7 +152,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -146,7 +167,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
@@ -154,7 +175,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -162,7 +183,7 @@ const context: Context = {
     [
       'widgets/widget-1/item',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -170,7 +191,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -178,7 +199,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -186,7 +207,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -194,7 +215,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -202,7 +223,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule',
       {
-        Args: undefined,
+        Args: ['concert'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -210,7 +231,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -218,7 +239,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -226,7 +247,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -234,7 +255,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -242,7 +263,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -250,7 +271,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -258,7 +279,7 @@ const context: Context = {
     [
       'widgets/widget-5',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -47,7 +47,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -55,7 +55,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -63,7 +63,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: ['HTMLDivElement', 'HTMLImageElement'],
       },
@@ -71,7 +71,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -87,7 +87,7 @@ const context: Context = {
     [
       'tracks/table',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLTableElement'],
       },
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -103,7 +103,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -111,7 +118,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -122,7 +129,7 @@ const context: Context = {
     [
       'ui/form/information',
       {
-        Args: undefined,
+        Args: ['formId', 'instructions', 'title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -130,7 +137,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -138,7 +152,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -146,7 +167,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
@@ -154,7 +175,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -162,7 +183,7 @@ const context: Context = {
     [
       'widgets/widget-1/item',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -170,7 +191,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -178,7 +199,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -186,7 +207,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -194,7 +215,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -202,7 +223,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule',
       {
-        Args: undefined,
+        Args: ['concert'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -210,7 +231,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -218,7 +239,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -226,7 +247,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -234,7 +255,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -242,7 +263,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -250,7 +271,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -258,7 +279,7 @@ const context: Context = {
     [
       'widgets/widget-5',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },


### PR DESCRIPTION
## Description

Partially implements #27. In the `analyze-project` step, we can now find out a component's arguments from its template.

The list of arguments (a sorted array) has been stored in `signatureMap` (the step's return value) so that we can later fill out `Signature['Args']` in the `update-signatures` step.
