### PR TITLE
Fill out Signature['Args'] (Part 2)

### DIFF
--- a/src/steps/update-signatures/builders.ts
+++ b/src/steps/update-signatures/builders.ts
@@ -31,6 +31,15 @@ function builderConvertTsTypeToKeyword(tsType: string) {
   }
 }
 
+export function builderCreateArgsNode(signature: Signature) {
+  return AST.builders.tsPropertySignature(
+    AST.builders.identifier('Args'),
+    // @ts-ignore: Assume that types from external packages are correct
+    AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral([])),
+    false,
+  );
+}
+
 export function builderCreateBlocksNode(signature: Signature) {
   if (signature.Blocks === undefined) {
     return;

--- a/src/steps/update-signatures/builders.ts
+++ b/src/steps/update-signatures/builders.ts
@@ -32,10 +32,21 @@ function builderConvertTsTypeToKeyword(tsType: string) {
 }
 
 export function builderCreateArgsNode(signature: Signature) {
+  const members: unknown[] = [];
+
+  (signature.Args ?? []).forEach((argumentName) => {
+    members.push(
+      AST.builders.tsPropertySignature(
+        AST.builders.identifier(argumentName),
+        AST.builders.tsTypeAnnotation(AST.builders.tsUnknownKeyword()),
+      ),
+    );
+  });
+
   return AST.builders.tsPropertySignature(
     AST.builders.identifier('Args'),
     // @ts-ignore: Assume that types from external packages are correct
-    AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral([])),
+    AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(members)),
     false,
   );
 }

--- a/src/steps/update-signatures/update-signature.ts
+++ b/src/steps/update-signatures/update-signature.ts
@@ -2,6 +2,7 @@ import { AST } from '@codemod-utils/ast-javascript';
 
 import type { Signature } from '../../types/index.js';
 import {
+  builderCreateArgsNode,
   builderCreateBlocksNode,
   builderCreateElementNode,
 } from './builders.js';
@@ -39,7 +40,14 @@ export function updateSignature(file: string, data: Data): string {
         return false;
       }
 
-      const ArgsNode = getBodyNode(path.node, 'Args');
+      const argsNode = getBodyNode(path.node, 'Args');
+
+      const isArgsKnown =
+        argsNode?.typeAnnotation.typeAnnotation.members.length > 0;
+
+      const ArgsNode = isArgsKnown
+        ? argsNode
+        : builderCreateArgsNode(data.signature);
 
       const BlocksNode =
         getBodyNode(path.node, 'Blocks') ??

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/tracks.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/tracks.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
 }
 
 const TracksComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/tracks/table.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
 }
 
 const TracksTableComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/information.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/ui/form/information.ts
@@ -1,7 +1,11 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
-  Args: {};
+  Args: {
+    formId: unknown;
+    instructions: unknown;
+    title: unknown;
+  };
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-1/item.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-1/item.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
-  Args: {};
+  Args: {
+    title: unknown;
+  };
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/ember-container-query-addon/output/addon/components/widgets/widget-3/tour-schedule.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
+  Args: {
+    concert: unknown;
+  };
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-1.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-1.ts
@@ -1,6 +1,7 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1Signature {
+  Args: {};
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-2.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-2.ts
@@ -9,7 +9,6 @@ import {
 } from '../../utils/components/widgets/widget-2';
 
 interface WidgetsWidget2Signature {
-  // eslint-disable-next-line @typescript-eslint/ban-types
   Args: {};
 }
 

--- a/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-3.ts
+++ b/tests/fixtures/ember-container-query-glint/output/src/components/widgets/widget-3.ts
@@ -5,7 +5,6 @@ import type { Concert } from '../../data/concert';
 import concertData from '../../data/concert';
 
 interface WidgetsWidget3Signature {
-  // eslint-disable-next-line @typescript-eslint/ban-types
   Args: {};
 }
 

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/index.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/ember-container-query-nested/output/app/components/tracks/table/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/tracks/table/index.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLTableElement;
 }
 

--- a/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/information/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/ui/form/information/index.ts
@@ -1,7 +1,11 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
-  Args: {};
+  Args: {
+    formId: unknown;
+    instructions: unknown;
+    title: unknown;
+  };
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/item/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-1/item/index.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
-  Args: {};
+  Args: {
+    title: unknown;
+  };
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/tour-schedule/index.ts
+++ b/tests/fixtures/ember-container-query-nested/output/app/components/widgets/widget-3/tour-schedule/index.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
+  Args: {
+    concert: unknown;
+  };
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/navigation-menu.ts
@@ -1,7 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface NavigationMenuSignature {
-  Args: {};
+  Args: {
+    menuItems: unknown;
+    name: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/card.ts
@@ -1,7 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface ProductsProductCardSignature {
-  Args: {};
+  Args: {
+    product: unknown;
+    redirectTo: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/products/product/image.ts
@@ -2,7 +2,9 @@ import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
 interface ProductsProductImageSignature {
-  Args: {};
+  Args: {
+    src: unknown;
+  };
   Element: HTMLDivElement | HTMLImageElement;
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface TracksSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface TracksListSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLUListElement;
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/table.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLTableElement;
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
@@ -4,7 +4,10 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 interface UiFormSignature {
-  Args: {};
+  Args: {
+    instructions: unknown;
+    title: unknown;
+  };
   Blocks: {
     default: [unknown];
   };

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/checkbox.ts
@@ -2,7 +2,14 @@ import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
 interface UiFormCheckboxSignature {
-  Args: {};
+  Args: {
+    isDisabled: unknown;
+    isInline: unknown;
+    isReadOnly: unknown;
+    isRequired: unknown;
+    isWide: unknown;
+    label: unknown;
+  };
 }
 
 export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/field.ts
@@ -2,7 +2,11 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 interface UiFormFieldSignature {
-  Args: {};
+  Args: {
+    errorMessage: unknown;
+    isInline: unknown;
+    isWide: unknown;
+  };
   Blocks: {
     field: [unknown];
     label: [unknown];

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/information.ts
@@ -1,7 +1,11 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
-  Args: {};
+  Args: {
+    formId: unknown;
+    instructions: unknown;
+    title: unknown;
+  };
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
@@ -2,7 +2,14 @@ import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
 interface UiFormInputSignature {
-  Args: {};
+  Args: {
+    isDisabled: unknown;
+    isReadOnly: unknown;
+    isRequired: unknown;
+    isWide: unknown;
+    label: unknown;
+    placeholder: unknown;
+  };
 }
 
 export default class UiFormInputComponent extends Component<UiFormInputSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/textarea.ts
@@ -2,7 +2,14 @@ import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
 interface UiFormTextareaSignature {
-  Args: {};
+  Args: {
+    isDisabled: unknown;
+    isReadOnly: unknown;
+    isRequired: unknown;
+    isWide: unknown;
+    label: unknown;
+    placeholder: unknown;
+  };
 }
 
 export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/page.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface UiPageSignature {
-  Args: {};
+  Args: {
+    title: unknown;
+  };
   Blocks: {
     default: [];
   };

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1/item.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-1/item.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
-  Args: {};
+  Args: {
+    title: unknown;
+  };
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface WidgetsWidget2StackedChartSignature {
-  Args: {};
+  Args: {
+    data: unknown;
+  };
 }
 
 export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
+  Args: {
+    concert: unknown;
+  };
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4MemoActionsSignature {
-  Args: {};
+  Args: {
+    cqFeatures: unknown;
+  };
 }
 
 const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface WidgetsWidget4MemoBodySignature {
-  Args: {};
+  Args: {
+    cqFeatures: unknown;
+  };
 }
 
 const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface WidgetsWidget4MemoHeaderSignature {
-  Args: {};
+  Args: {
+    cqFeatures: unknown;
+  };
 }
 
 const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}

--- a/tests/fixtures/ember-container-query/output/app/components/tracks.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/ember-container-query/output/app/components/tracks/table.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/tracks/table.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksTableSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLTableElement;
 }
 

--- a/tests/fixtures/ember-container-query/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/ui/form/information.ts
@@ -1,7 +1,11 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
-  Args: {};
+  Args: {
+    formId: unknown;
+    instructions: unknown;
+    title: unknown;
+  };
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1/item.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-1/item.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget1ItemSignature {
-  Args: {};
+  Args: {
+    title: unknown;
+  };
 }
 
 const WidgetsWidget1ItemComponent =

--- a/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/ember-container-query/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
+  Args: {
+    concert: unknown;
+  };
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/tracks.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface TracksSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/fixtures/steps/update-signatures/has-declaration-file/output/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget3TourScheduleSignature {
-  Args: {};
+  Args: {
+    concert: unknown;
+  };
 }
 
 const WidgetsWidget3TourScheduleComponent =

--- a/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
+++ b/tests/fixtures/steps/update-signatures/has-hbs-file-only/output/app/components/ui/form/information.ts
@@ -1,7 +1,11 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface UiFormInformationSignature {
-  Args: {};
+  Args: {
+    formId: unknown;
+    instructions: unknown;
+    title: unknown;
+  };
 }
 
 const UiFormInformationComponent =

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/navigation-menu.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/navigation-menu.ts
@@ -1,7 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface NavigationMenuSignature {
-  Args: {};
+  Args: {
+    menuItems: unknown;
+    name: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/card.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/card.ts
@@ -1,7 +1,10 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface ProductsProductCardSignature {
-  Args: {};
+  Args: {
+    product: unknown;
+    redirectTo: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/image.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/products/product/image.ts
@@ -2,7 +2,9 @@ import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
 interface ProductsProductImageSignature {
-  Args: {};
+  Args: {
+    src: unknown;
+  };
   Element: HTMLDivElement | HTMLImageElement;
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface TracksSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLElement;
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface TracksListSignature {
-  Args: {};
+  Args: {
+    tracks: unknown;
+  };
   Element: HTMLUListElement;
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.ts
@@ -4,7 +4,10 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 interface UiFormSignature {
-  Args: {};
+  Args: {
+    instructions: unknown;
+    title: unknown;
+  };
   Blocks: {
     default: [unknown];
   };

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
@@ -2,7 +2,14 @@ import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
 interface UiFormCheckboxSignature {
-  Args: {};
+  Args: {
+    isDisabled: unknown;
+    isInline: unknown;
+    isReadOnly: unknown;
+    isRequired: unknown;
+    isWide: unknown;
+    label: unknown;
+  };
 }
 
 export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/field.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/field.ts
@@ -2,7 +2,11 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 interface UiFormFieldSignature {
-  Args: {};
+  Args: {
+    errorMessage: unknown;
+    isInline: unknown;
+    isWide: unknown;
+  };
   Blocks: {
     field: [unknown];
     label: [unknown];

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
@@ -2,7 +2,14 @@ import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
 interface UiFormInputSignature {
-  Args: {};
+  Args: {
+    isDisabled: unknown;
+    isReadOnly: unknown;
+    isRequired: unknown;
+    isWide: unknown;
+    label: unknown;
+    placeholder: unknown;
+  };
 }
 
 export default class UiFormInputComponent extends Component<UiFormInputSignature> {

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.ts
@@ -2,7 +2,14 @@ import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
 interface UiFormTextareaSignature {
-  Args: {};
+  Args: {
+    isDisabled: unknown;
+    isReadOnly: unknown;
+    isRequired: unknown;
+    isWide: unknown;
+    label: unknown;
+    placeholder: unknown;
+  };
 }
 
 export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/page.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/page.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface UiPageSignature {
-  Args: {};
+  Args: {
+    title: unknown;
+  };
   Blocks: {
     default: [];
   };

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface WidgetsWidget2StackedChartSignature {
-  Args: {};
+  Args: {
+    data: unknown;
+  };
 }
 
 export default class WidgetsWidget2StackedChartComponent extends Component<WidgetsWidget2StackedChartSignature> {}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/actions.ts
@@ -1,7 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 interface WidgetsWidget4MemoActionsSignature {
-  Args: {};
+  Args: {
+    cqFeatures: unknown;
+  };
 }
 
 const WidgetsWidget4MemoActionsComponent = templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/body.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface WidgetsWidget4MemoBodySignature {
-  Args: {};
+  Args: {
+    cqFeatures: unknown;
+  };
 }
 
 const WidgetsWidget4MemoBodyComponent = class extends Component<WidgetsWidget4MemoBodySignature> {}

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-4/memo/header.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 
 interface WidgetsWidget4MemoHeaderSignature {
-  Args: {};
+  Args: {
+    cqFeatures: unknown;
+  };
 }
 
 const WidgetsWidget4MemoHeaderComponent = class FooComponent extends Component<WidgetsWidget4MemoHeaderSignature> {}

--- a/tests/helpers/shared-test-setups/has-backing-class.ts
+++ b/tests/helpers/shared-test-setups/has-backing-class.ts
@@ -41,7 +41,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -49,7 +49,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -57,7 +57,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: ['HTMLDivElement', 'HTMLImageElement'],
       },
@@ -65,7 +65,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -73,7 +73,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -81,7 +81,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -89,7 +96,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -100,7 +107,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -108,7 +122,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -116,7 +137,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
@@ -124,7 +145,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -132,7 +153,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -140,7 +161,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -148,7 +169,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -156,7 +177,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -164,7 +185,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -172,7 +193,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -180,7 +201,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -188,7 +209,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -196,7 +217,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -204,7 +225,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-declaration-file.ts
+++ b/tests/helpers/shared-test-setups/has-declaration-file.ts
@@ -19,7 +19,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -27,7 +27,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule',
       {
-        Args: undefined,
+        Args: ['concert'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-hbs-file-only.ts
+++ b/tests/helpers/shared-test-setups/has-hbs-file-only.ts
@@ -19,7 +19,7 @@ const context: Context = {
     [
       'ui/form/information',
       {
-        Args: undefined,
+        Args: ['formId', 'instructions', 'title'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -27,7 +27,7 @@ const context: Context = {
     [
       'widgets/widget-5',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-no-args.ts
+++ b/tests/helpers/shared-test-setups/has-no-args.ts
@@ -42,7 +42,7 @@ const context: Context = {
     [
       'navigation-menu',
       {
-        Args: undefined,
+        Args: ['menuItems', 'name'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -50,7 +50,7 @@ const context: Context = {
     [
       'products/product/card',
       {
-        Args: undefined,
+        Args: ['product', 'redirectTo'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -58,7 +58,7 @@ const context: Context = {
     [
       'products/product/image',
       {
-        Args: undefined,
+        Args: ['src'],
         Blocks: undefined,
         Element: ['HTMLDivElement', 'HTMLImageElement'],
       },
@@ -66,7 +66,7 @@ const context: Context = {
     [
       'tracks',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -74,7 +74,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: undefined,
+        Args: ['tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -82,7 +82,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: undefined,
+        Args: ['instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -90,7 +90,14 @@ const context: Context = {
     [
       'ui/form/checkbox',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isInline',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -98,7 +105,7 @@ const context: Context = {
     [
       'ui/form/field',
       {
-        Args: undefined,
+        Args: ['errorMessage', 'isInline', 'isWide'],
         Blocks: new Map([
           ['field', ['unknown']],
           ['label', ['unknown']],
@@ -109,7 +116,14 @@ const context: Context = {
     [
       'ui/form/input',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -117,7 +131,14 @@ const context: Context = {
     [
       'ui/form/textarea',
       {
-        Args: undefined,
+        Args: [
+          'isDisabled',
+          'isReadOnly',
+          'isRequired',
+          'isWide',
+          'label',
+          'placeholder',
+        ],
         Blocks: undefined,
         Element: undefined,
       },
@@ -125,7 +146,7 @@ const context: Context = {
     [
       'ui/page',
       {
-        Args: undefined,
+        Args: ['title'],
         Blocks: new Map([['default', []]]),
         Element: ['HTMLDivElement'],
       },
@@ -133,7 +154,7 @@ const context: Context = {
     [
       'widgets/widget-1',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: ['HTMLElement'],
       },
@@ -141,7 +162,7 @@ const context: Context = {
     [
       'widgets/widget-2',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -149,7 +170,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -157,7 +178,7 @@ const context: Context = {
     [
       'widgets/widget-2/stacked-chart',
       {
-        Args: undefined,
+        Args: ['data'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -165,7 +186,7 @@ const context: Context = {
     [
       'widgets/widget-3',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -173,7 +194,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -181,7 +202,7 @@ const context: Context = {
     [
       'widgets/widget-4',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -189,7 +210,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo',
       {
-        Args: undefined,
+        Args: [],
         Blocks: undefined,
         Element: undefined,
       },
@@ -197,7 +218,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/actions',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -205,7 +226,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/body',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -213,7 +234,7 @@ const context: Context = {
     [
       'widgets/widget-4/memo/header',
       {
-        Args: undefined,
+        Args: ['cqFeatures'],
         Blocks: undefined,
         Element: undefined,
       },


### PR DESCRIPTION
## Description

Partially implements #27. In the `update-signatures` step, we can now partially fill out `Signature['Args']` for the end-developer.

Note, the codemod currently uses the empty object `{}` to indicate that the component doesn't receive any arguments. Glint, on the other hand, [recommends omitting the `'Args'` key](https://typed-ember.gitbook.io/glint/environments/ember/component-signatures) to record the absence.

> `Args` represents the arguments your component accepts. Typically this will be an object type mapping the names of your args to their expected type. If no `Args` key is specified, it will be a type error to pass any arguments to your component.

In a later task, we will want to refactor code to follow Glint's recommendations.
