### PR TITLE
Fill out Signature['Args'] (Part 3)

### DIFF
--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -1,7 +1,24 @@
-// import { AST as ASTJavaScript } from '@codemod-utils/ast-javascript';
+import { AST as ASTJavaScript } from '@codemod-utils/ast-javascript';
 import { AST as ASTTemplate } from '@codemod-utils/ast-template';
 
 import type { Signature } from '../../../types/index.js';
+
+function analyzeClass(file?: string): Set<string> {
+  const args = new Set<string>();
+
+  if (file === undefined) {
+    return args;
+  }
+
+  // We know that the file is in TypeScript
+  const traverse = ASTJavaScript.traverse(true);
+
+  traverse(file, {
+    // ...
+  });
+
+  return args;
+}
 
 function analyzeTemplate(file: string): Set<string> {
   const traverse = ASTTemplate.traverse();
@@ -35,12 +52,8 @@ export function findArguments({
   }
 
   const argsFromTemplate = analyzeTemplate(templateFile);
-
-  if (classFile !== undefined) {
-    // const argsFromClass = analyzeClass(classFile);
-  }
-
-  const args = new Set([...argsFromTemplate]);
+  const argsFromClass = analyzeClass(classFile);
+  const args = new Set([...argsFromTemplate, ...argsFromClass]);
 
   return Array.from(args).sort();
 }

--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -3,8 +3,9 @@ import { AST as ASTTemplate } from '@codemod-utils/ast-template';
 
 import type { Signature } from '../../../types/index.js';
 
-function analyzeTemplate(file: string, args: Set<string>): void {
+function analyzeTemplate(file: string): Set<string> {
   const traverse = ASTTemplate.traverse();
+  const args = new Set<string>();
 
   traverse(file, {
     PathExpression(node) {
@@ -18,6 +19,8 @@ function analyzeTemplate(file: string, args: Set<string>): void {
       args.add(key);
     },
   });
+
+  return args;
 }
 
 export function findArguments({
@@ -31,13 +34,13 @@ export function findArguments({
     return;
   }
 
-  const args = new Set<string>();
-
-  analyzeTemplate(templateFile, args);
+  const argsFromTemplate = analyzeTemplate(templateFile);
 
   if (classFile !== undefined) {
-    // analyzeClass(classFile, args);
+    // const argsFromClass = analyzeClass(classFile);
   }
+
+  const args = new Set([...argsFromTemplate]);
 
   return Array.from(args).sort();
 }

--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -23,14 +23,14 @@ function analyzeClass(file?: string): Set<string> {
       }
 
       switch (node.value.property.type) {
-        // Matches the pattern `this.args.foo`
+        // Matches the pattern `this.args.someArgument`
         case 'Identifier': {
           args.add(node.value.property.name as string);
 
           break;
         }
 
-        // Matches the pattern `this.args['foo']`
+        // Matches the pattern `this.args['someArgument']`
         case 'StringLiteral': {
           args.add(node.value.property.value as string);
 
@@ -46,7 +46,7 @@ function analyzeClass(file?: string): Set<string> {
       let isValid = false;
 
       switch (rightHandSide.type) {
-        // Matches the pattern `const { foo } = this.args;`
+        // Matches the pattern `const { someArgument } = this.args;`
         case 'MemberExpression': {
           if (
             rightHandSide.object.type !== 'ThisExpression' ||
@@ -61,7 +61,7 @@ function analyzeClass(file?: string): Set<string> {
           break;
         }
 
-        // Matches the pattern `const { foo } = this.args as Args;`
+        // Matches the pattern `const { someArgument } = this.args as SomeType;`
         case 'TSAsExpression': {
           if (
             rightHandSide.expression.type !== 'MemberExpression' ||

--- a/src/steps/analyze-project/analyze-components/find-arguments.ts
+++ b/src/steps/analyze-project/analyze-components/find-arguments.ts
@@ -14,7 +14,32 @@ function analyzeClass(file?: string): Set<string> {
   const traverse = ASTJavaScript.traverse(true);
 
   traverse(file, {
-    // ...
+    visitMemberExpression(node) {
+      if (
+        node.value.object.type !== 'MemberExpression' ||
+        node.value.object.property.name !== 'args'
+      ) {
+        return false;
+      }
+
+      switch (node.value.property.type) {
+        // Matches the pattern `this.args.foo`
+        case 'Identifier': {
+          args.add(node.value.property.name as string);
+
+          break;
+        }
+
+        // Matches the pattern `this.args['foo']`
+        case 'StringLiteral': {
+          args.add(node.value.property.value as string);
+
+          break;
+        }
+      }
+
+      return false;
+    },
   });
 
   return args;

--- a/src/steps/update-signatures/builders.ts
+++ b/src/steps/update-signatures/builders.ts
@@ -31,13 +31,19 @@ function builderConvertTsTypeToKeyword(tsType: string) {
   }
 }
 
+function needsQuotations(key: string): boolean {
+  return key.includes('-');
+}
+
 export function builderCreateArgsNode(signature: Signature) {
   const members: unknown[] = [];
 
   (signature.Args ?? []).forEach((argumentName) => {
     members.push(
       AST.builders.tsPropertySignature(
-        AST.builders.identifier(argumentName),
+        needsQuotations(argumentName)
+          ? AST.builders.stringLiteral(argumentName)
+          : AST.builders.identifier(argumentName),
         AST.builders.tsTypeAnnotation(AST.builders.tsUnknownKeyword()),
       ),
     );
@@ -61,7 +67,9 @@ export function builderCreateBlocksNode(signature: Signature) {
   signature.Blocks.forEach((positionalArgumentTypes, blockName) => {
     members.push(
       AST.builders.tsPropertySignature(
-        AST.builders.identifier(blockName),
+        needsQuotations(blockName)
+          ? AST.builders.stringLiteral(blockName)
+          : AST.builders.identifier(blockName),
         AST.builders.tsTypeAnnotation(
           AST.builders.tsTupleType(
             positionalArgumentTypes.map(builderConvertTsTypeToKeyword),

--- a/tests/fixtures/ember-container-query-no-args/input/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-no-args/input/app/components/tracks/list.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 export default class TracksListComponent extends Component {
   get numColumns(): number {
-    const { numColumns } = this.args;
+    const { 'num-columns': numColumns } = this.args;
 
     return numColumns ?? 1;
   }

--- a/tests/fixtures/ember-container-query-no-args/input/app/components/ui/form.hbs
+++ b/tests/fixtures/ember-container-query-no-args/input/app/components/ui/form.hbs
@@ -41,6 +41,7 @@
           onUpdate=this.updateChangeset
         )
       )
+      to="the-default-block"
     }}
   </ContainerQuery>
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 interface TracksListSignature {
   Args: {
+    numColumns: unknown;
     tracks: unknown;
   };
   Element: HTMLUListElement;

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/tracks/list.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 interface TracksListSignature {
   Args: {
-    numColumns: unknown;
+    'num-columns': unknown;
     tracks: unknown;
   };
   Element: HTMLUListElement;
@@ -10,7 +10,7 @@ interface TracksListSignature {
 
 export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {
-    const { numColumns } = this.args;
+    const { 'num-columns': numColumns } = this.args;
 
     return numColumns ?? 1;
   }

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.hbs
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.hbs
@@ -41,6 +41,7 @@
           onUpdate=this.updateChangeset
         )
       )
+      to="the-default-block"
     }}
   </ContainerQuery>
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
@@ -10,7 +10,7 @@ interface UiFormSignature {
     title: unknown;
   };
   Blocks: {
-    default: [unknown];
+    'the-default-block': [unknown];
   };
   Element: HTMLFormElement;
 }

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form.ts
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 interface UiFormSignature {
   Args: {
+    data: unknown;
     instructions: unknown;
     title: unknown;
   };

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/checkbox.ts
@@ -3,12 +3,15 @@ import Component from '@glimmer/component';
 
 interface UiFormCheckboxSignature {
   Args: {
+    changeset: unknown;
     isDisabled: unknown;
     isInline: unknown;
     isReadOnly: unknown;
     isRequired: unknown;
     isWide: unknown;
+    key: unknown;
     label: unknown;
+    onUpdate: unknown;
   };
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
@@ -9,6 +9,7 @@ interface UiFormInputSignature {
     isWide: unknown;
     label: unknown;
     placeholder: unknown;
+    type: unknown;
   };
 }
 

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/input.ts
@@ -3,11 +3,14 @@ import Component from '@glimmer/component';
 
 interface UiFormInputSignature {
   Args: {
+    changeset: unknown;
     isDisabled: unknown;
     isReadOnly: unknown;
     isRequired: unknown;
     isWide: unknown;
+    key: unknown;
     label: unknown;
+    onUpdate: unknown;
     placeholder: unknown;
     type: unknown;
   };

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/ui/form/textarea.ts
@@ -3,11 +3,14 @@ import Component from '@glimmer/component';
 
 interface UiFormTextareaSignature {
   Args: {
+    changeset: unknown;
     isDisabled: unknown;
     isReadOnly: unknown;
     isRequired: unknown;
     isWide: unknown;
+    key: unknown;
     label: unknown;
+    onUpdate: unknown;
     placeholder: unknown;
   };
 }

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-2/captions.ts
@@ -16,7 +16,9 @@ const colorSvg = modifier((container: Element, [color]: [string]) => {
 });
 
 interface WidgetsWidget2CaptionsSignature {
-  Args: {};
+  Args: {
+    summaries: unknown;
+  };
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {

--- a/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/ember-container-query-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -6,7 +6,9 @@ import { containerQuery, type Dimensions } from 'ember-container-query';
 import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
 
 interface WidgetsWidget3TourScheduleResponsiveImageSignature {
-  Args: {};
+  Args: {
+    images: unknown;
+  };
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/tracks/list.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 interface TracksListSignature {
   Args: {
+    numColumns: unknown;
     tracks: unknown;
   };
   Element: HTMLUListElement;

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form.ts
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 interface UiFormSignature {
   Args: {
+    data: unknown;
     instructions: unknown;
     title: unknown;
   };

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/checkbox.ts
@@ -3,12 +3,15 @@ import Component from '@glimmer/component';
 
 interface UiFormCheckboxSignature {
   Args: {
+    changeset: unknown;
     isDisabled: unknown;
     isInline: unknown;
     isReadOnly: unknown;
     isRequired: unknown;
     isWide: unknown;
+    key: unknown;
     label: unknown;
+    onChange: unknown;
   };
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
@@ -9,6 +9,7 @@ interface UiFormInputSignature {
     isWide: unknown;
     label: unknown;
     placeholder: unknown;
+    type: unknown;
   };
 }
 

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/input.ts
@@ -3,11 +3,14 @@ import Component from '@glimmer/component';
 
 interface UiFormInputSignature {
   Args: {
+    changeset: unknown;
     isDisabled: unknown;
     isReadOnly: unknown;
     isRequired: unknown;
     isWide: unknown;
+    key: unknown;
     label: unknown;
+    onUpdate: unknown;
     placeholder: unknown;
     type: unknown;
   };

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/ui/form/textarea.ts
@@ -3,11 +3,14 @@ import Component from '@glimmer/component';
 
 interface UiFormTextareaSignature {
   Args: {
+    changeset: unknown;
     isDisabled: unknown;
     isReadOnly: unknown;
     isRequired: unknown;
     isWide: unknown;
+    key: unknown;
     label: unknown;
+    onUpdate: unknown;
     placeholder: unknown;
   };
 }

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/captions.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-2/captions.ts
@@ -16,7 +16,9 @@ const colorSvg = modifier((container: Element, [color]: [string]) => {
 });
 
 interface WidgetsWidget2CaptionsSignature {
-  Args: {};
+  Args: {
+    summaries: unknown;
+  };
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {

--- a/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/update-signatures/has-no-args/output/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -6,7 +6,9 @@ import { containerQuery, type Dimensions } from 'ember-container-query';
 import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
 
 interface WidgetsWidget3TourScheduleResponsiveImageSignature {
-  Args: {};
+  Args: {
+    images: unknown;
+  };
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {

--- a/tests/helpers/shared-test-setups/ember-container-query-addon.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-addon.ts
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: undefined,
       },
@@ -141,11 +141,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -157,11 +160,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -235,7 +241,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-addon.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-addon.ts
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: undefined,
       },
@@ -104,12 +104,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -144,6 +147,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -199,7 +203,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-glint.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-glint.ts
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -104,12 +104,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -138,11 +141,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -154,11 +160,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -232,7 +241,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-glint.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-glint.ts
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -144,6 +144,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -199,7 +200,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-nested.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-nested.ts
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -141,11 +141,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -157,11 +160,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -235,7 +241,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-nested.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-nested.ts
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -104,12 +104,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -144,6 +147,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -199,7 +203,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -141,11 +141,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -157,11 +160,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -235,7 +241,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -104,12 +104,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -144,6 +147,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -199,7 +203,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query-no-args.ts
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['numColumns', 'tracks'],
+        Args: ['num-columns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -96,7 +96,7 @@ const context: Context = {
       'ui/form',
       {
         Args: ['data', 'instructions', 'title'],
-        Blocks: new Map([['default', ['unknown']]]),
+        Blocks: new Map([['the-default-block', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
     ],

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -79,7 +79,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -141,11 +141,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -157,11 +160,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -235,7 +241,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/ember-container-query.ts
+++ b/tests/helpers/shared-test-setups/ember-container-query.ts
@@ -95,7 +95,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -104,12 +104,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -144,6 +147,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -199,7 +203,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-backing-class.ts
+++ b/tests/helpers/shared-test-setups/has-backing-class.ts
@@ -73,7 +73,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -82,12 +82,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -114,6 +117,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -161,7 +165,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-backing-class.ts
+++ b/tests/helpers/shared-test-setups/has-backing-class.ts
@@ -65,7 +65,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -111,11 +111,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -127,11 +130,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -189,7 +195,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-no-args.ts
+++ b/tests/helpers/shared-test-setups/has-no-args.ts
@@ -74,7 +74,7 @@ const context: Context = {
     [
       'tracks/list',
       {
-        Args: ['tracks'],
+        Args: ['numColumns', 'tracks'],
         Blocks: undefined,
         Element: ['HTMLUListElement'],
       },
@@ -120,11 +120,14 @@ const context: Context = {
       'ui/form/input',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
           'type',
         ],
@@ -136,11 +139,14 @@ const context: Context = {
       'ui/form/textarea',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onUpdate',
           'placeholder',
         ],
         Blocks: undefined,
@@ -198,7 +204,7 @@ const context: Context = {
     [
       'widgets/widget-3/tour-schedule/responsive-image',
       {
-        Args: [],
+        Args: ['images'],
         Blocks: undefined,
         Element: undefined,
       },

--- a/tests/helpers/shared-test-setups/has-no-args.ts
+++ b/tests/helpers/shared-test-setups/has-no-args.ts
@@ -82,7 +82,7 @@ const context: Context = {
     [
       'ui/form',
       {
-        Args: ['instructions', 'title'],
+        Args: ['data', 'instructions', 'title'],
         Blocks: new Map([['default', ['unknown']]]),
         Element: ['HTMLFormElement'],
       },
@@ -91,12 +91,15 @@ const context: Context = {
       'ui/form/checkbox',
       {
         Args: [
+          'changeset',
           'isDisabled',
           'isInline',
           'isReadOnly',
           'isRequired',
           'isWide',
+          'key',
           'label',
+          'onChange',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -123,6 +126,7 @@ const context: Context = {
           'isWide',
           'label',
           'placeholder',
+          'type',
         ],
         Blocks: undefined,
         Element: undefined,
@@ -170,7 +174,7 @@ const context: Context = {
     [
       'widgets/widget-2/captions',
       {
-        Args: [],
+        Args: ['summaries'],
         Blocks: undefined,
         Element: undefined,
       },


### PR DESCRIPTION
## Description

Closes #27. In the `analyze-project` step, we can now read arguments from the component's backing class.

To ensure that the project can be maintained, I covered the usual 80%:

- `this.args.someArgument`
- `this.args['someArgument']`
- `const { someArgument } = this.args;`
- `const { someArgument } = this.args as SomeType;`

In these 4 cases, the codemod will recognize `someArgument` as an argument of the component. In other cases, it will likely fail to, so the end-developer must standardize their syntax before running the codemod.

In addition, the codemod can handle the edge of dasherized names. Dasherized names should be uncommon for arguments, but can occur for blocks. See the related [linting rule from `ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint/blob/v5.11.1/docs/rule/require-valid-named-block-naming-format.md).
